### PR TITLE
Aggregate results

### DIFF
--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -124,11 +124,15 @@ jobs:
       gcchash: ${{ needs.init-submodules.outputs.gcchash }}
       multilib: ${{ matrix.multilib }}
 
-  generate-issues:
+    outputs:
+      gcchash: ${{ needs.init-submodules.outputs.gcchash }}
+
+  summarize:
     if: always() # Generate github issues even when some (or all) targets fail to build
-    runs-on: ubuntu-22.04
     needs: [creg]
-    steps:
-      - name: Generate summary
-        run: |
-          echo Filing issue...
+    permissions:
+      issues: write
+    uses: ./.github/workflows/summary-runner.yaml
+    with:
+      gcchash: ${{ needs.creg.outputs.gcchash }}
+

--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -124,9 +124,6 @@ jobs:
       gcchash: ${{ needs.init-submodules.outputs.gcchash }}
       multilib: ${{ matrix.multilib }}
 
-    outputs:
-      gcchash: ${{ needs.init-submodules.outputs.gcchash }}
-
   summarize:
     if: always() # Generate github issues even when some (or all) targets fail to build
     needs: [init-submodules, creg]

--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -129,10 +129,10 @@ jobs:
 
   summarize:
     if: always() # Generate github issues even when some (or all) targets fail to build
-    needs: [creg]
+    needs: [init-submodules, creg]
     permissions:
       issues: write
     uses: ./.github/workflows/summary-runner.yaml
     with:
-      gcchash: ${{ needs.creg.outputs.gcchash }}
+      gcchash: ${{ needs.init-submodules.outputs.gcchash }}
 

--- a/.github/workflows/summary-runner.yaml
+++ b/.github/workflows/summary-runner.yaml
@@ -1,0 +1,85 @@
+on:
+  workflow_call:
+    inputs:
+      gcchash:
+        required: true
+        type: string
+
+jobs:
+  compare-artifacts:
+    runs-on: ubuntu-22.04
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+          
+      - name: Download and compare
+        run: |
+          pip install pygithub requests
+          mkdir logs
+          mkdir summaries
+          python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Make artifact zips
+        run: |
+          zip -r summaries.zip summaries
+          zip -r logs.zip logs
+
+      - name: Upload compare summaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.gcchash }}-summaries
+          path: |
+            summaries.zip
+          retention-days: 5
+
+      - name: Upload log failures
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.gcchash }}-logs
+          path: |
+            logs.zip
+          retention-days: 5
+
+    outputs:
+      gcchash: ${{ inputs.gcchash }}
+
+  
+  generate-issues:
+    needs: [compare-artifacts]
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download summaries artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.compare-artifacts.outputs.gcchash }}-summaries
+
+      - name: Download logs artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.compare-artifacts.outputs.gcchash }}-logs
+
+      - name: Aggregate information
+        run: |
+          unzip summaries.zip
+          unzip logs.zip
+          python ./scripts/aggregate.py \
+            -chash ${{ needs.compare-artifacts.outputs.gcchash }} \
+            -o out.md
+          cat out.md
+
+      - name: trim script output (same hash)
+        run: |
+          head -100 out.md > test.md
+          cat test.md
+
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: test.md
+          assignees: patrick-rivos, kevinl-rivosinc, ewlu
+          update_existing: true

--- a/.github/workflows/summary-runner.yaml
+++ b/.github/workflows/summary-runner.yaml
@@ -4,9 +4,17 @@ on:
       gcchash:
         required: true
         type: string
+  workflow_dispatch:
+    branches:
+      - build-frequent
+    inputs:
+      gcchash:
+        description: 'GCC Hash'
+        required: true
 
 jobs:
   compare-artifacts:
+    if: always() # ensure comparison always runs even on error
     runs-on: ubuntu-22.04
     environment: production
     steps:
@@ -30,7 +38,7 @@ jobs:
           name: ${{ inputs.gcchash }}-summaries
           path: |
             summaries.zip
-          retention-days: 5
+          retention-days: 90
 
       - name: Upload log failures
         uses: actions/upload-artifact@v3
@@ -38,13 +46,14 @@ jobs:
           name: ${{ inputs.gcchash }}-logs
           path: |
             logs.zip
-          retention-days: 5
+          retention-days: 90
 
     outputs:
       gcchash: ${{ inputs.gcchash }}
 
   
   generate-issues:
+    if: always() # ensure generate issues always runs even on error
     needs: [compare-artifacts]
     runs-on: ubuntu-22.04
     permissions:
@@ -68,18 +77,17 @@ jobs:
           unzip logs.zip
           python ./scripts/aggregate.py \
             -chash ${{ needs.compare-artifacts.outputs.gcchash }} \
-            -o out.md
-          cat out.md
+            -o issue.md
+          cat issue.md
 
-      - name: trim script output (same hash)
+      - name: Trim issue length # reduce the number of lines in final issue so github always creates issue
         run: |
-          head -100 out.md > test.md
-          cat test.md
+          head -100 issue.md > trimmed_issue.md
+          cat trimmed_issue.md
 
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filename: test.md
-          assignees: patrick-rivos, kevinl-rivosinc, ewlu
+          filename: trimmed_issue.md
           update_existing: true

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -1,0 +1,136 @@
+import argparse
+import os
+from collections import defaultdict
+
+SUMMARIES = "./summaries"
+FAILURES = "./logs"
+
+
+def get_additional_failures(file_name: str, failure_name: str, seen_failures: set):
+    """ Search for build and testsuite failures """
+    result = f"|{failure_name}|Additional Info|\n"
+    result += "|---|---|\n"
+    file_path = os.path.join(FAILURES, f"{file_name}")
+    failures = defaultdict(set)
+    if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
+        with open(file_path, "r") as f:
+            while True:
+                line = f.readline().strip()
+                if not line:
+                    break
+                artifact, comment = line.split("|")
+                failures[artifact].add(comment)
+        for failure, comment in failures.items():
+            if failure not in seen_failures:
+                result += f"|{failure}|{';'.join(comment)}|\n"
+                seen_failures.add(failure)
+        result += "\n"
+        return result, seen_failures
+    return "", seen_failures
+
+def build_summary(failures: dict, failure_name: str):
+    """ Builds table in summary section """
+    tools = ("gcc", "g++", "gfortran")
+    result = f"|{failure_name}|{tools[0]}|{tools[1]}|{tools[2]}|Previous Hash|\n"
+    result += "|---|---|---|---|---|\n"
+    result += f"{''.join(failures[failure_name.split(' ')[0]])}"
+    result += "\n"
+    return result
+
+def failures_to_summary(failures: dict):
+    """ Builds summary section """
+    result = "# Summary\n"
+    seen_failures = set()
+    additional_result, seen_failures = get_additional_failures("failed_build.txt", "Build Failures", seen_failures)
+    result += additional_result
+    additional_result, seen_failures = get_additional_failures("failed_testsuite", "Testsuite Failures", seen_failures)
+    result += additional_result
+
+    result += build_summary(failures, "Resolved Failures")
+    result += build_summary(failures, "Unresolved Failures")
+    result += build_summary(failures, "New Failures")
+    result += "\n"
+    return result
+
+def assign_labels(file_name, label):
+    """Creates label for issue"""
+    file_path = os.path.join(FAILURES, f"{file_name}")
+    if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
+        return label
+    return ""
+
+def failures_to_markdown(failures: dict, current_hash: str):
+    assignees = ["patrick-rivos", "kevinl-rivosinc", "ewlu"]
+    result = f"""---
+title: Testsuite Status {current_hash}
+assignees: {", ".join(assignees)}
+"""
+    labels = {"bug"}
+    labels.add(assign_labels("failed_build.txt", "build-failure"))
+    labels.add(assign_labels("failed_testsuite.txt", "testsuite-failure"))
+    if "" in labels:
+        labels.remove("")
+    result += f"labels: {', '.join(labels)}\n"
+    result += "---\n\n"
+    result += failures_to_summary(failures)
+    return result
+
+def aggregate_summary(failures: dict, file_name: str):
+    """
+    Reads file and adds the new failures to the current
+    list of failures
+    """
+    with open(file_name, "r") as f:
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            if line.startswith("# Summary"):
+                break
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            if "#" in line:
+                # exited Summary section and going to New Failures section
+                # TODO: add support for consolidating these sections
+                break
+            if "Failures" in line:
+                index = line.split("Failures")[0][1:-1]
+                continue
+            if line != "\n" and "---" not in line:
+                failures[index].add(line)
+    return failures
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Testsuite Compare Options")
+    parser.add_argument(
+        "-chash",
+        "--current-hash",
+        metavar="<string>",
+        required=True,
+        type=str,
+        help="Commit hash of the current GCC testsuite log",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-markdown",
+        default="./testsuite.md",
+        metavar="<filename>",
+        type=str,
+        help="Path to the current testsuite result log",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    failures = { "Resolved": set(), "Unresolved": set(), "New": set() }
+    for file in os.listdir(SUMMARIES):
+        failures = aggregate_summary(failures, os.path.join(SUMMARIES, file))
+    markdown = failures_to_markdown(failures, args.current_hash)
+    with open(args.output_markdown, "w") as markdown_file:
+        markdown_file.write(markdown)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_testsuite_log.py
+++ b/scripts/compare_testsuite_log.py
@@ -371,7 +371,7 @@ def is_result_valid(log_path: str):
                     return False
         return True
 
-def run(previous_hash: str, previous_log: str, current_hash: str, current_log: str, output_markdown: str):
+def compare_logs(previous_hash: str, previous_log: str, current_hash: str, current_log: str, output_markdown: str):
     if not is_result_valid(previous_log):
         raise RuntimeError(f"{previous_log} doesn't include Summary of the testsuite")
     if not is_result_valid(current_log):
@@ -384,7 +384,7 @@ def run(previous_hash: str, previous_log: str, current_hash: str, current_log: s
 
 def main():
     args = parse_arguments()
-    run(args.previous_hash, args.previous_log, args.current_hash, args.current_log, args.output_markdown)
+    compare_logs(args.previous_hash, args.previous_log, args.current_hash, args.current_log, args.output_markdown)
 
 
 if __name__ == "__main__":

--- a/scripts/compare_testsuite_log.py
+++ b/scripts/compare_testsuite_log.py
@@ -345,6 +345,8 @@ def is_result_valid(log_path: str):
         summary_flag = False
         while True:
             line = file.readline()
+            if not line:
+                break
             if line.startswith(
                 "               ========= Summary of gcc testsuite ========="
             ):
@@ -369,17 +371,20 @@ def is_result_valid(log_path: str):
                     return False
         return True
 
+def run(previous_hash: str, previous_log: str, current_hash: str, current_log: str, output_markdown: str):
+    if not is_result_valid(previous_log):
+        raise RuntimeError(f"{previous_log} doesn't include Summary of the testsuite")
+    if not is_result_valid(current_log):
+        raise RuntimeError(f"{current_log} doesn't include Summary of the testsuite")
+    failures = compare_testsuite_log(previous_log, current_log)
+    markdown = failures_to_markdown(failures, previous_hash, current_hash)
+    with open(output_markdown, "w") as markdown_file:
+        markdown_file.write(markdown)
+    
 
 def main():
     args = parse_arguments()
-    if not is_result_valid(args.previous_log):
-        raise RuntimeError("Previous Log doesn't include Summary of the testsuite")
-    if not is_result_valid(args.current_log):
-        raise RuntimeError("Current Log doesn't include Summary of the testsuite")
-    failures = compare_testsuite_log(args.previous_log, args.current_log)
-    markdown = failures_to_markdown(failures, args.previous_hash, args.current_hash)
-    with open(args.output_markdown, "w") as markdown_file:
-        markdown_file.write(markdown)
+    run(args.previous_hash, args.previous_log, args.current_hash, args.current_log, args.output_markdown)
 
 
 if __name__ == "__main__":

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -1,0 +1,151 @@
+import argparse
+import requests
+import os
+import importlib
+
+from github import Auth, Github, Repository
+from zipfile import ZipFile
+from get_most_recent_ci_hash import gcc_hashes, get_valid_artifact_hash
+from compare_testsuite_log import run
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Download valid log artifacts")
+    parser.add_argument(
+        "-hash",
+        required=True,
+        type=str,
+        help="Commit hash of GCC to get artifacts for",
+    )
+    parser.add_argument(
+        "-token",
+        required=True,
+        type=str,
+        help="Github access token",
+    )
+    return parser.parse_args()
+
+def get_possible_artifact_names():
+    """
+    Generates all possible permutations of target artifact logs and
+    removes unsupported targets
+
+    Current Support:
+      Linux: rv32/64 multilib non-multilib
+      Newlib: rv32/64 non-multilib
+      Arch extensions: gc
+    """
+    libc = ["gcc-linux", "gcc-newlib"]
+    arch = ["rv32{}-ilp32d-{}", "rv64{}-lp64d-{}"]
+    multilib = ["multilib", "non-multilib"]
+
+    arch_extensions = ["gc"]
+
+    all_lists = ["-".join([i, j, k]) for i in libc
+                                     for j in arch
+                                     for k in multilib
+                                     if not ("rv32" in j and k == "multilib")]
+
+    all_names = [name.format(ext, "{}") for name in all_lists
+                                        for ext in arch_extensions]
+    return all_names
+
+def check_artifact_exists(artifact_name: str, repo: Repository):
+    """
+    @param artifact_name is the artifact associated with build success
+    If the artifact does not exist, something failed and logs error into
+    appropriate file; else returns artifact id for downloading
+    """
+    build_name = artifact_name
+    build_failed = False
+    artifact = repo.get_artifacts(artifact_name).get_page(0)
+    # check build failed
+    if len(artifact) == 0:
+        print(f"build failed for {build_name}")
+        build_failed = True
+        with open("./logs/failed_build.txt", "a+") as f:
+            f.write(f"{build_name}|Check logs\n")
+    # check testsuite failed
+    artifact_name += "-report.log"
+    artifact = repo.get_artifacts(artifact_name).get_page(0)
+    if len(artifact) == 0:
+        print(f"testsuite failed for {build_name}")
+        if not build_failed:
+            with open("./logs/failed_testsuite.txt", "a+") as f:
+                f.write(f"{build_name}|Cannot find testsuite artifact\n")
+        return -1
+    return artifact[0].id
+
+def download_artifact(artifact_name: str, artifact_id: str, token: str):
+    """
+    Uses GitHub api endpoint to download and extract the log artifact into
+    directory called ./logs
+    """
+    params = {"Accept": "application/vnd.github+json",
+              "Authorization": f"token {token}",
+              "X-Github-Api-Version": "2022-11-28"}
+    artifact_zip_name = artifact_name.replace(".log", ".zip")
+    print(artifact_zip_name)
+    print(f"downloading: {artifact_id}")
+    r = requests.get(f"https://api.github.com/repos/patrick-rivos/riscv-gnu-toolchain/actions/artifacts/{artifact_id}/zip", headers=params)
+    print(r.status_code)
+    with open(f"./{artifact_zip_name}", "wb") as f:
+        f.write(r.content)
+    with ZipFile(f"./{artifact_zip_name}", "r") as zf:
+        zf.extractall(path=f"./{artifact_name.split('.log')[0]}")
+    os.rename(f"./{artifact_name.split('.log')[0]}/{artifact_name}", f"./logs/{artifact_name}")
+
+def download_all_artifacts(current_hash: str, token: str):
+    """
+    Goes through all possible artifact targets and downloads it
+    if it exists. Downloads previous successful hash's artifact
+    as well. Runs comparison on the downloaded artifacts
+    """
+
+    auth = Auth.Token(token)
+    g = Github(auth=auth)
+
+    repo = g.get_repo("patrick-rivos/riscv-gnu-toolchain")
+
+    prev_commits = gcc_hashes(current_hash, False)
+    artifact_names = get_possible_artifact_names()
+    for artifact_name in artifact_names:
+        artifact = artifact_name.format(current_hash)
+        artifact_id = check_artifact_exists(artifact, repo)
+        if artifact_id == -1:
+            continue
+        # comparison output path
+        compare_path = f"./summaries/{artifact + '-report-summary.md'}"
+        artifact += "-report.log"
+        artifact_name += "-report.log"
+        # download current artifact
+        download_artifact(artifact, str(artifact_id), token)
+
+        # download previous artifact
+        base_hash, base_id = get_valid_artifact_hash(prev_commits, token, artifact_name)
+        if base_hash == "No valid hash":
+            print(f"no baseline for {artifact}")
+            with open("./logs/no_baseline.txt", "a+") as f:
+                f.write(f"{artifact}\n")
+            base_hash = current_hash + "-no-baseline"
+            try:
+                run(base_hash, f"./logs/{artifact}", base_hash, f"./logs/{artifact}", compare_path)
+            except (RuntimeError, ValueError) as err:
+                with open("./logs/failed_testsuite.txt", "a+") as f:
+                    f.write(f"{artifact}|{err}\n")
+            continue
+        download_artifact(artifact_name.format(base_hash), str(base_id), token)
+        try:
+            run(base_hash, f"./logs/{artifact_name.format(base_hash)}",
+                   current_hash, f"./logs/{artifact}", compare_path)
+        except (RuntimeError, ValueError) as err:
+            with open("./logs/failed_testsuite.txt", "a+") as f:
+                f.write(f"{artifact}|{err}\n")
+
+    return
+
+def main():
+    args = parse_arguments()
+    download_all_artifacts(args.hash, args.token)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get-most-recent-ci-hash.py
+++ b/scripts/get-most-recent-ci-hash.py
@@ -19,6 +19,20 @@ def gcc_hashes(hash: str, subsequent: bool):
 
     return commits
 
+def get_valid_artifact_hash(hashes:List[str], token: str, artifact_name: str):
+    auth = Auth.Token(token)
+    g = Github(auth=auth)
+
+    repo = g.get_repo('patrick-rivos/riscv-gnu-toolchain')
+
+    for hash in hashes:
+        artifacts = repo.get_artifacts(artifact_name.format(hash)).get_page(0)
+        if len(artifacts) != 0:
+            return hash, artifacts[0].id
+
+    return "No valid hash", -1
+  
+
 def get_valid_hash(hashes: List[str], token: str):
     auth = Auth.Token(token)
     g = Github(auth=auth)

--- a/scripts/get_most_recent_ci_hash.py
+++ b/scripts/get_most_recent_ci_hash.py
@@ -20,6 +20,10 @@ def gcc_hashes(hash: str, subsequent: bool):
     return commits
 
 def get_valid_artifact_hash(hashes:List[str], token: str, artifact_name: str):
+    """ 
+    Searches for the most recent GCC hash that has the artifact specified by
+    @param artifact_name. Also returns id of found artifact for download
+    """
     auth = Auth.Token(token)
     g = Github(auth=auth)
 

--- a/scripts/get_most_recent_ci_hash.py
+++ b/scripts/get_most_recent_ci_hash.py
@@ -36,22 +36,6 @@ def get_valid_artifact_hash(hashes:List[str], token: str, artifact_name: str):
 
     return "No valid hash", -1
   
-
-def get_valid_hash(hashes: List[str], token: str):
-    auth = Auth.Token(token)
-    g = Github(auth=auth)
-
-    repo = g.get_repo('patrick-rivos/riscv-gnu-toolchain')
-
-    for hash in hashes:
-        # Arbitrarily use gcc-newlib-rv32gc-ilp32d. It seems to always build.
-        artifact_name = f'gcc-newlib-rv32gc-ilp32d-{hash}-non-multilib-report.log'
-        artifacts = repo.get_artifacts(artifact_name).get_page(0)
-        if len(artifacts) != 0:
-            return hash
-
-    return "No valid hash"
-
 def main(hash: str, subsequent: bool, token: str):
     commits = gcc_hashes(hash, subsequent)
     print(get_valid_hash(commits, token))


### PR DESCRIPTION
- The `download_artifacts.py` script checks the repo for existing artifacts and will download all testsuite artifacts associated with the provided hash (specified with -hash input) and the previous successful hash. Failures are logged in the `./logs/` directory where:
  -  `./logs/failed_build.txt` contains the names of artifacts without `-report.log` in the file name and cannot be found for the specified hash
  - `./logs/failed_testsuite.txt` contains the names of artifacts with `-report.log` in the file name and cannot be found for the specified hash
  - `./logs/no_baseline.txt` contains the names of artifacts with `-report.log` in the file name but a previous successful hash cannot be found to compare against
- `aggregate.py` parses through all summaries output by `compare-testsuite-log.py` (used by `download_artifacts.py`) and consolidates the summaries into one markdown file. Currently, only the summary tables are included and the failed test case reporting is removed.
- `get-most-recent-ci-hash.py` is used by `download_artifacts.py` to get the 100 most recent commits from the specified commit and searches for the artifacts within that list
- Updated `build-frequent.yaml` to support downloading, comparing, and reporting summaries of the changes