### PR TITLE
Clone GCC before attempting to find artifacts

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -1,3 +1,5 @@
+name: Generate-Summary
+
 on:
   workflow_call:
     inputs:
@@ -19,8 +21,39 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v3
-          
-      - name: Download and compare
+
+      - name: Retrieve cache
+        id: retrieve-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .git
+            binutils
+            dejagnu
+            gcc
+            gdb
+            glibc
+            musl
+            newlib
+            pk
+            qemu
+          key: submodules
+
+      - name: Initalize gcc
+        if: steps.retrieve-cache.outputs.cache-hit != 'true'
+        run: |
+          rm -rf gcc
+          git clone git://gcc.gnu.org/git/gcc.git
+          git submodule update --recursive --progress --recommend-shallow
+
+      - name: Pull gcc
+        id: gcc-hash
+        run: |
+          cd gcc
+          git checkout master
+          git pull
+
+      - name: Download artifacts and compare
         run: |
           pip install pygithub requests
           mkdir logs
@@ -51,7 +84,6 @@ jobs:
     outputs:
       gcchash: ${{ inputs.gcchash }}
 
-  
   generate-issues:
     if: always() # ensure generate issues always runs even on error
     needs: [compare-artifacts]

--- a/.github/workflows/regression-runner.yaml
+++ b/.github/workflows/regression-runner.yaml
@@ -1,3 +1,5 @@
+name: Regression-Runner
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Currently all summaries will fail to find a baseline. Cloning GCC before attempting to download artifacts will fix this.