### PR TITLE
Fix artifact download

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Download artifacts and compare
         run: |
           pip install pygithub requests
-          mkdir logs
+          mkdir -p logs/current
           mkdir summaries
           python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -token ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -59,14 +59,105 @@ jobs:
           mkdir temp
           mkdir summaries
 
-      - name: Download current workflow artifacts
+      # Download all workload artifacts
+
+      # Download linux
+      - name: Download rv32 non-multilib
         uses: actions/download-artifact@v3
         with:
+          name: gcc-linux-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
           path: "./temp"
+        continue-on-error: true
 
+      - name: Download rv32 non-multilib binary
+        if: hashFiles('./temp/gcc-linux-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log') == ''
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-linux-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 non-multilib
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 non-multilib binary
+        if: hashFiles('./temp/gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log') == ''
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 multilib
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-multilib-report.log
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 multilib binary
+        if: hashFiles('./temp/gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-multilib-report.log') == ''
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-multilib
+          path: "./temp"
+        continue-on-error: true
+
+     # Download newlib
+      - name: Download rv32 non-multilib
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-newlib-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv32 non-multilib binary
+        if: hashFiles('./temp/gcc-newlib-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log') == ''
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-newlib-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 non-multilib
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 non-multilib binary
+        if: hashFiles('./temp/gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log') == ''
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 multilib
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-multilib-report.log
+          path: "./temp"
+        continue-on-error: true
+
+      - name: Download rv64 multilib binary
+        if: hashFiles('./temp/gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-multilib-report.log') == ''
+        uses: actions/download-artifact@v3
+        with:
+          name: gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-multilib
+          path: "./temp"
+        continue-on-error: true
+ 
+      # End download
+ 
       - name: Extract artifacts
         run:
-          unzip ./temp/*/*report.log.zip -d ./logs
+          unzip ./temp/*report.log.zip -d ./logs
           ls logs
 
       - name: Download artifacts and compare

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -53,11 +53,25 @@ jobs:
           git checkout master
           git pull
 
+      - name: Create directories
+        run: |
+          mkdir logs
+          mkdir temp
+          mkdir summaries
+
+      - name: Download current workflow artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: "./temp"
+
+      - name: Extract artifacts
+        run:
+          unzip ./temp/*/*report.log.zip -d ./logs
+          ls logs
+
       - name: Download artifacts and compare
         run: |
           pip install pygithub requests
-          mkdir -p logs/current
-          mkdir summaries
           python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Make artifact zips

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -43,7 +43,7 @@ def failures_to_summary(failures: dict):
     seen_failures = set()
     additional_result, seen_failures = get_additional_failures("failed_build.txt", "Build Failures", seen_failures)
     result += additional_result
-    additional_result, seen_failures = get_additional_failures("failed_testsuite", "Testsuite Failures", seen_failures)
+    additional_result, seen_failures = get_additional_failures("failed_testsuite.txt", "Testsuite Failures", seen_failures)
     result += additional_result
 
     result += build_summary(failures, "Resolved Failures")

--- a/scripts/compare_testsuite_log.py
+++ b/scripts/compare_testsuite_log.py
@@ -300,26 +300,26 @@ def compare_testsuite_log(previous_log_path: str, current_log_path: str):
     return classified_gcc_failures
 
 
-def gccfailure_to_summary(failure: Dict[LibName, GccFailure], failure_name):
+def gccfailure_to_summary(failure: Dict[LibName, GccFailure], failure_name: str, previous_hash: str):
     tools = ("gcc", "g++", "gfortran")
-    result = f"|{failure_name}|{tools[0]}|{tools[1]}|{tools[2]}|\n"
-    result +="|---|---|---|---|\n"
+    result = f"|{failure_name}|{tools[0]}|{tools[1]}|{tools[2]}|Previous Hash|\n"
+    result +="|---|---|---|---|---|\n"
     for libname, gccfailure in failure.items():
         result += f"|{libname}|"
         for tool in tools:
             tool_failure_key = f"{tool}_failure_count"
             # convert tuple of counts to string
             result += f"{'/'.join(gccfailure[tool_failure_key])}|"
-        result += "\n"
+        result += f"{previous_hash}|\n"
     result += "\n"
     return result
 
 
-def failures_to_summary(failures: ClassifedGccFailures):
+def failures_to_summary(failures: ClassifedGccFailures, previous_hash: str):
     result = "# Summary\n"
-    result += gccfailure_to_summary(failures.resolved, "Resolved Failures")
-    result += gccfailure_to_summary(failures.unresolved, "Unresolved Failures")
-    result += gccfailure_to_summary(failures.new, "New Failures")
+    result += gccfailure_to_summary(failures.resolved, "Resolved Failures", previous_hash)
+    result += gccfailure_to_summary(failures.unresolved, "Unresolved Failures", previous_hash)
+    result += gccfailure_to_summary(failures.new, "New Failures", previous_hash)
     result += "\n"
     return result
 
@@ -333,7 +333,7 @@ title: {previous_hash}->{current_hash}
 assignees: {str(assignees)}
 labels: bug
 ---\n"""
-    result += failures_to_summary(failures)
+    result += failures_to_summary(failures, previous_hash)
     result += str(failures)
     return result
 

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -64,7 +64,7 @@ def check_artifact_exists(artifact_name: str):
     build_name = artifact_name
     build_failed = False
     # check if the build failed
-    if not os.path.exists(os.path.join("./temp", artifact_name)):
+    if not os.path.exists(os.path.join("./temp", f"{artifact_name}.zip")):
         print(f"build failed for {build_name}")
         build_failed = True
         with open("./logs/failed_build.txt", "a+") as f:

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -62,16 +62,17 @@ def check_artifact_exists(artifact_name: str):
     appropriate file
     """
     build_name = artifact_name
+    artifact_name += "-report.log"
     build_failed = False
     # check if the build failed
-    if not os.path.exists(os.path.join("./temp", f"{artifact_name}.zip")):
+    if (not os.path.exists(os.path.join("./temp", f"{build_name}.zip")) and
+        not os.path.exists(os.path.join("./logs", artifact_name))):
         print(f"build failed for {build_name}")
         build_failed = True
         with open("./logs/failed_build.txt", "a+") as f:
             f.write(f"{build_name}|Check logs\n")
 
     # check if the testsuite failed
-    artifact_name += "-report.log"
     if not os.path.exists(os.path.join("./logs", artifact_name)):
         print(f"testsuite failed for {build_name}")
         if not build_failed:


### PR DESCRIPTION
Updates:
- Fixed missing hashes under `Previous Hashes` column in issue summary
- Update current workflow artifact download to use `actions/download-artifact@v3` for all supported file logs and binaries (if the logs didn't exist)
