### PR TITLE
Add more targets and refactor multilib targets

### DIFF
--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -32,6 +32,10 @@ on:
         options:
         - rv32gc-ilp32d
         - rv64gc-lp64d
+        - rv32gcv-ilp32d
+        - rv64gcv-lp64d
+        - rv32gc_zba_zbb_zbc_zbs-ilp32d
+        - rv64gc_zba_zbb_zbc_zbs-lp64d
 
 jobs:
   init-submodules:
@@ -120,19 +124,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode:   [newlib, linux, musl]
-        target: [rv32gc-ilp32d, rv64gc-lp64d]
-        multilib: [multilib, non-multilib]
+        mode: [newlib, linux, musl]
+        target:
+          [
+            rv32gc-ilp32d, # rv32
+            rv64gc-lp64d, # rv64
+            rv32gcv-ilp32d, # rv32 vector
+            rv64gcv-lp64d, # rv64 vector
+            rv32gc_zba_zbb_zbc_zbs-ilp32d, # rv32 bitmanip
+            rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
+          ]
+        multilib: [non-multilib]
         exclude:
           - mode: musl
             target: rv32gc-ilp32d
           - mode: musl
-            multilib: multilib
-          # Multilib ignores the target.
-          # Aribtrarily use rv64 as the single multilib runner.
-          # If we add more targets in the future, just exclude those cases from the multilib case.
-          - target: rv32gc-ilp32d
-            multilib: multilib
+            target: rv32gcv-ilp32d
+          - mode: musl
+            target: rv32gc_zba_zbb_zbc_zbs-ilp32d
+    uses: ./.github/workflows/regression-runner.yaml
+    with:
+      mode: ${{ matrix.mode }}
+      target: ${{ matrix.target }}
+      gcchash: ${{ needs.init-submodules.outputs.gcchash }}
+      multilib: ${{ matrix.multilib }}
+
+  cmreg: # Check Multilib Regressions. Short name so I can see the matrix string in github
+    needs: [init-submodules]
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [newlib, linux]
+        target: [rv64gc-lp64d] # Dummy placeholder. Actually runs rv32/rv64 multilib
+        multilib: [multilib]
     uses: ./.github/workflows/regression-runner.yaml
     with:
       mode: ${{ matrix.mode }}
@@ -151,15 +175,15 @@ jobs:
       multilib: non-multilib
 
   build-x86:
-    if: failure() # Only check x86 if riscv fails
-    needs: [init-submodules, creg]
+    if: failure() # Only check x86 if a riscv build fails
+    needs: [init-submodules, creg, cmreg]
     uses: ./.github/workflows/bootstrap-x86.yaml
     with:
       gcchash: ${{ needs.init-submodules.outputs.gcchash }}
 
   summarize:
-    if: '!cancelled()' # Generate github issues even when some (or all) targets fail to build
-    needs: [init-submodules, creg, csreg]
+    if: "!cancelled()" # Generate github issues even when some (or all) targets fail to build
+    needs: [init-submodules, creg, cmreg, csreg]
     permissions:
       issues: write
     uses: ./.github/workflows/generate-summary.yaml

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -83,6 +83,34 @@ jobs:
           binary-artifact-name: gcc-linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download linux rv32 vector non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv64gcv-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv64gcv-ilp32d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download linux rv64 vector non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv64gcv-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv64gcv-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download linux rv32 bitmanip non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download linux rv64 bitmanip non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # Newlib
       - name: Download newlib rv32 non-multilib
         uses: ./.github/actions/download-comparison-artifacts
@@ -96,6 +124,34 @@ jobs:
         with:
           report-artifact-name: gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
           binary-artifact-name: gcc-newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib rv32 vector non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv32gcv-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv32gcv-ilp32d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib rv64 vector non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv64gcv-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv64gcv-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib rv32 bitmanip non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib rv64 bitmanip non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Multilib

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -86,8 +86,8 @@ jobs:
       - name: Download linux rv32 vector non-multilib
         uses: ./.github/actions/download-comparison-artifacts
         with:
-          report-artifact-name: gcc-linux-rv64gcv-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
-          binary-artifact-name: gcc-linux-rv64gcv-ilp32d-${{ inputs.gcchash }}-non-multilib
+          report-artifact-name: gcc-linux-rv32gcv-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv32gcv-ilp32d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download linux rv64 vector non-multilib

--- a/.github/workflows/regression-runner.yaml
+++ b/.github/workflows/regression-runner.yaml
@@ -171,9 +171,13 @@ jobs:
           touch -d "+2 days" build-glibc-linux-rv32gc-ilp32d
           touch -d "+2 days" build-glibc-linux-rv32imac-ilp32
           touch -d "+2 days" build-glibc-linux-rv32imafdc-ilp32d
+          touch -d "+2 days" build-glibc-linux-rv32gcv-ilp32d
+          touch -d "+2 days" build-glibc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d
           touch -d "+2 days" build-glibc-linux-rv64gc-lp64d
           touch -d "+2 days" build-glibc-linux-rv64imac-lp64
           touch -d "+2 days" build-glibc-linux-rv64imafdc-lp64d
+          touch -d "+2 days" build-glibc-linux-rv64gcv-lp64d
+          touch -d "+2 days" build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d
           touch -d "+2 days" build-newlib-nano
           touch -d "+2 days" build-${{ inputs.mode }}
           touch -d "+2 days" merge-newlib-nano

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -51,12 +51,12 @@ def get_possible_artifact_names():
         for j in arch
         for k in multilib
         if not ("rv32" in j and k == "multilib")
-        and not ("rv64gcv" in j and k == "multilib")
-        and not ("rv64gc_" in j and k == "multilib")
     ]
-
+    
     all_names = [
         name.format(ext, "{}") for name in all_lists for ext in arch_extensions
+        if not ("gcv" in ext and "non-multilib" not in name)
+        and not ("gc_" in ext and "non-multilib" not in name)
     ]
     return all_names
 

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -39,7 +39,11 @@ def get_possible_artifact_names():
     arch = ["rv32{}-ilp32d-{}", "rv64{}-lp64d-{}"]
     multilib = ["multilib", "non-multilib"]
 
-    arch_extensions = ["gc"]
+    arch_extensions = [
+        "gc",
+        "gcv",
+        "gc_zba_zbb_zbc_zbs"
+    ]
 
     all_lists = [
         "-".join([i, j, k])
@@ -47,6 +51,8 @@ def get_possible_artifact_names():
         for j in arch
         for k in multilib
         if not ("rv32" in j and k == "multilib")
+        and not ("rv64gcv" in j and k == "multilib")
+        and not ("rv64gc_" in j and k == "multilib")
     ]
 
     all_names = [


### PR DESCRIPTION
Adds vector and bitmanip. Vector crypto needs to wait till the Binutils 2.41 release this coming Sunday (7/30).