### PR TITLE
Add single target runner

### DIFF
--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -17,6 +17,21 @@ on:
       gcchash:
         description: 'GCC Hash'
         required: true
+      run_single_target:
+        type: boolean
+        description: 'Leave unchecked to run all targets'
+      single_mode:
+        type: choice
+        description: 'Choose a mode'
+        options:
+        - newlib
+        - linux
+      single_target:
+        type: choice
+        description: 'Choose a target'
+        options:
+        - rv32gc-ilp32d
+        - rv64gc-lp64d
 
 jobs:
   init-submodules:
@@ -100,6 +115,7 @@ jobs:
       gcchash: ${{ steps.gcc-hash.outputs.gcchash }}
 
   creg: # Check Regressions. Short name so I can see the matrix string in github
+    if: ${{ github.event.inputs.run_single_target != 'true' || github.event.inputs.single_mode == '' || github.event.inputs.single_target == '' }}
     needs: [init-submodules]
     strategy:
       fail-fast: false
@@ -124,6 +140,16 @@ jobs:
       gcchash: ${{ needs.init-submodules.outputs.gcchash }}
       multilib: ${{ matrix.multilib }}
 
+  csreg: # Check Single Target Regressions.
+    if: ${{ github.event.inputs.run_single_target == 'true' && github.event.inputs.single_mode != '' && github.event.inputs.single_target != '' }}
+    needs: [init-submodules]
+    uses: ./.github/workflows/regression-runner.yaml
+    with:
+      mode: ${{ github.event.inputs.single_mode }}
+      target: ${{ github.event.inputs.single_target }}
+      gcchash: ${{ needs.init-submodules.outputs.gcchash }}
+      multilib: non-multilib
+
   build-x86:
     if: failure() # Only check x86 if riscv fails
     needs: [init-submodules, creg]
@@ -133,10 +159,9 @@ jobs:
 
   summarize:
     if: '!cancelled()' # Generate github issues even when some (or all) targets fail to build
-    needs: [init-submodules, creg]
+    needs: [init-submodules, creg, csreg]
     permissions:
       issues: write
     uses: ./.github/workflows/generate-summary.yaml
     with:
       gcchash: ${{ needs.init-submodules.outputs.gcchash }}
-


### PR DESCRIPTION
Adds the ability to run a single target from the github CI. Useful when bisecting failures, but generates issues that look like they have build failures for the un-run targets.