### PR TITLE
Associate scheduled runs with trunk-regressions project automatically

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -263,10 +263,19 @@ jobs:
           run_id=${{ github.run_id }} && echo "Associated run is: https://github.com/patrick-rivos/riscv-gnu-toolchain/actions/runs/$run_id" >> trimmed_issue.md
           cat trimmed_issue.md
 
-
-      - uses: JasonEtco/create-an-issue@v2
+      - name: Create or update summary issue
+        uses: JasonEtco/create-an-issue@v2
+        id: create-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: trimmed_issue.md
           update_existing: true
+
+      - name: Associate issue with project # Only scheduled jobs are guarenteed to track trunk.
+        if: ${{ github.event_name == 'schedule' }}
+        uses: peter-evans/create-or-update-project-card@v2
+        with:
+          project-name: Trunk-Regressions
+          column-name: No Status
+          issue-number: ${{ steps.create-issue.outputs.number }}


### PR DESCRIPTION
This automatically associates new issues with the trunk-regressions project _if_ they were made by a scheduled run.

This is hard to test without duplicating the project, but since this step runs last it will likely not impact anything even if it doesn't work.