### PR TITLE
Add vector crypto and remove musl builds

### DIFF
--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -36,6 +36,8 @@ on:
         - rv64gcv-lp64d
         - rv32gc_zba_zbb_zbc_zbs-ilp32d
         - rv64gc_zba_zbb_zbc_zbs-lp64d
+        - rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d
+        - rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
 
 jobs:
   init-submodules:
@@ -124,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode: [newlib, linux, musl]
+        mode: [newlib, linux]
         target:
           [
             rv32gc-ilp32d, # rv32
@@ -133,15 +135,10 @@ jobs:
             rv64gcv-lp64d, # rv64 vector
             rv32gc_zba_zbb_zbc_zbs-ilp32d, # rv32 bitmanip
             rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
+            rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d, # rv32 vector crypto
+            rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d, # rv64 vector crypto
           ]
         multilib: [non-multilib]
-        exclude:
-          - mode: musl
-            target: rv32gc-ilp32d
-          - mode: musl
-            target: rv32gcv-ilp32d
-          - mode: musl
-            target: rv32gc_zba_zbb_zbc_zbs-ilp32d
     uses: ./.github/workflows/regression-runner.yaml
     with:
       mode: ${{ matrix.mode }}

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -111,6 +111,20 @@ jobs:
           binary-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download linux rv32 vector crypto non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download linux rv64 vector crypto non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # Newlib
       - name: Download newlib rv32 non-multilib
         uses: ./.github/actions/download-comparison-artifacts
@@ -152,6 +166,20 @@ jobs:
         with:
           report-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
           binary-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib rv32 vector crypto non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib rv64 vector crypto non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Multilib

--- a/.github/workflows/regression-runner.yaml
+++ b/.github/workflows/regression-runner.yaml
@@ -173,11 +173,13 @@ jobs:
           touch -d "+2 days" build-glibc-linux-rv32imafdc-ilp32d
           touch -d "+2 days" build-glibc-linux-rv32gcv-ilp32d
           touch -d "+2 days" build-glibc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d
+          touch -d "+2 days" build-glibc-linux-rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d
           touch -d "+2 days" build-glibc-linux-rv64gc-lp64d
           touch -d "+2 days" build-glibc-linux-rv64imac-lp64
           touch -d "+2 days" build-glibc-linux-rv64imafdc-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gcv-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d
+          touch -d "+2 days" build-glibc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
           touch -d "+2 days" build-newlib-nano
           touch -d "+2 days" build-${{ inputs.mode }}
           touch -d "+2 days" merge-newlib-nano

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -42,7 +42,8 @@ def get_possible_artifact_names():
     arch_extensions = [
         "gc",
         "gcv",
-        "gc_zba_zbb_zbc_zbs"
+        "gc_zba_zbb_zbc_zbs",
+        "gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt"
     ]
 
     all_lists = [
@@ -52,7 +53,7 @@ def get_possible_artifact_names():
         for k in multilib
         if not ("rv32" in j and k == "multilib")
     ]
-    
+
     all_names = [
         name.format(ext, "{}") for name in all_lists for ext in arch_extensions
         if not ("gcv" in ext and "non-multilib" not in name)


### PR DESCRIPTION
We haven't seen any failures from musl specifically, so this patch removes it so we can add more newlib/linux targets like vector crypto.