### PR TITLE
Revert "Remove gcc allowlist"

### DIFF
--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -1,0 +1,47 @@
+#
+# Check for nop insns fails due to ".option nopic".
+#
+FAIL: c-c++-common/patchable_function_entry-decl.c
+FAIL: c-c++-common/patchable_function_entry-default.c
+FAIL: c-c++-common/patchable_function_entry-definition.c
+#
+# XXX: Need review.
+#
+XPASS: gcc.dg/attr-alloc_size-11.c
+#
+# We didn't define TARGET_HAVE_SPECULATION_SAFE_VALUE or
+# speculation_barrier pattern
+#
+FAIL: c-c++-common/spec-barrier-1.c
+#
+# Upstream fail cases due to target check with 'vect_slp_v2hi_store_align' and 'vect_slp_v4hi_store_unalign'
+#
+FAIL: gcc.dg/Warray-bounds-48.c
+FAIL: gcc.dg/Wzero-length-array-bounds-2.c
+FAIL: gcc.dg/uninit-pred-9_b.c
+XPASS: gcc.dg/uninit-pred-7_a.c
+# Upstream regression,
+# Patch by Palmer:
+#   https://gcc.gnu.org/pipermail/gcc-patches/2022-May/593995.html
+# Discuss in:
+#   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102892
+FAIL: gcc.dg/analyzer/pr104308.c
+FAIL: gcc.dg/pr102892-1.c
+#
+# Upstream fail cases due to tree dump check
+#
+# Patch by Palmer:
+# https://gcc.gnu.org/pipermail/gcc-patches/2022-September/600932.html
+#
+FAIL: gcc.dg/tree-ssa/ssa-sink-18.c
+#
+# Upstream fixed cases
+#
+# By Palmer:
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=010af1040bcf4870c8f1aac88a7b1538f622858b
+FAIL: gcc.dg/debug/btf/btf-datasec-1.c
+# By Jiawei:
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=dc32901a0221a43e121591b9819b4e33bcc2fd0a
+FAIL: g++.dg/opt/const7.C
+#   https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b18e5d7e5f9df69759f0fbc2bed91d5e51313e79
+FAIL: gcc.target/riscv/pr105666.c

--- a/test/allowlist/gcc/glibc.ilp32.log
+++ b/test/allowlist/gcc/glibc.ilp32.log
@@ -1,0 +1,2 @@
+FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c

--- a/test/allowlist/gcc/glibc.log
+++ b/test/allowlist/gcc/glibc.log
@@ -1,0 +1,10 @@
+#
+# XXX: Need review why.
+#
+FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+FAIL: gfortran.dg/ieee/ieee_6.f90
+#
+# Synchronization problem.
+#
+FAIL: gcc.dg/tree-prof/time-profiler-2.c

--- a/test/allowlist/gcc/glibc.lp64.log
+++ b/test/allowlist/gcc/glibc.lp64.log
@@ -1,0 +1,2 @@
+FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c
+XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c

--- a/test/allowlist/gcc/glibc.rv32.f.log
+++ b/test/allowlist/gcc/glibc.rv32.f.log
@@ -1,0 +1,2 @@
+# Relocation truncated.
+FAIL: gcc.dg/torture/vec-cvt-1.c   -O0  (test for excess errors)

--- a/test/allowlist/gcc/glibc.rv32.log
+++ b/test/allowlist/gcc/glibc.rv32.log
@@ -1,0 +1,10 @@
+#
+FAIL: g++.dg/torture/pr86763.C
+#
+# It's new failed case since GCC 11,
+# this case only failed on -O0
+# But...I (Kito) don't know fortran too much,
+# so put this here for now until someday we have time to
+# investigating...
+#
+FAIL: gfortran.dg/assumed_rank_bounds_3.f90

--- a/test/allowlist/gcc/lp64.log
+++ b/test/allowlist/gcc/lp64.log
@@ -1,0 +1,5 @@
+#
+# fesetround not work with soft-fp
+#
+#FAIL: gcc.dg/torture/fp-int-convert-timode-3.c
+#FAIL: gcc.dg/torture/fp-int-convert-timode-4.c

--- a/test/allowlist/gcc/newlib-nano.f.log
+++ b/test/allowlist/gcc/newlib-nano.f.log
@@ -1,0 +1,4 @@
+#
+# errno, failed because newlib nano didn't build with _POSIX_MODE
+#
+FAIL: gcc.dg/torture/pr68264.c

--- a/test/allowlist/gcc/newlib-nano.log
+++ b/test/allowlist/gcc/newlib-nano.log
@@ -1,0 +1,34 @@
+#
+# We didn't init thread pointer in qemu nor newlib.
+#
+FAIL: gcc.dg/tls/pr78796.c execution test
+FAIL: g++.dg/cpp2a/decomp2.C
+#
+# freopen with stdout not work correctly for newlib
+#
+FAIL: gcc.c-torture/execute/user-printf.c
+FAIL: gcc.c-torture/execute/fprintf-2.c
+FAIL: gcc.c-torture/execute/printf-2.c
+#
+# newlib-nano didn't print out floating point by default,
+# program must link with -u_printf_float.
+#
+FAIL: g++.old-deja/g++.brendan/nest21.C
+FAIL: gcc.dg/torture/builtin-sprintf.c
+FAIL: gcc.dg/tree-ssa/builtin-sprintf.c
+FAIL: gcc.c-torture/execute/930513-1.c
+FAIL: gcc.c-torture/execute/920501-8.c
+FAIL: gcc.c-torture/execute/ieee/920810-1.c
+FAIL: gcc.c-torture/execute/printf-2.c
+#
+# newlib nano using LITE_EXIT,  __register_exitproc won't link by default,
+# so dtor of global var not work properly.
+# Program must link with -u __register_exitproc to work properly.
+#
+FAIL: g++.dg/init/ref15.C
+FAIL: g++.old-deja/g++.other/init18.C
+FAIL: g++.old-deja/g++.pt/static11.C
+#
+# Missing dg-require-effective-target shared
+#
+FAIL: g++.dg/lto/pr87906

--- a/test/allowlist/gcc/newlib.log
+++ b/test/allowlist/gcc/newlib.log
@@ -1,0 +1,19 @@
+#
+# We didn't init thread pointer in qemu nor newlib.
+#
+FAIL: g++.dg/cpp2a/decomp2.C
+#
+# freopen with stdout not work correctly for newlib
+#
+FAIL: gcc.c-torture/execute/user-printf.c
+FAIL: gcc.c-torture/execute/fprintf-2.c
+FAIL: gcc.c-torture/execute/printf-2.c
+#
+# -lc not enough to link final executable for newlib.
+#
+FAIL: g++.dg/abi/pure-virtual1.C
+#
+# newlib header issue, `reent.h`has complication warning when compile
+# with `-Wall`
+#
+FAIL: g++.dg/warn/Wstringop-overflow-6.C

--- a/test/allowlist/gcc/rv64.log
+++ b/test/allowlist/gcc/rv64.log
@@ -1,0 +1,4 @@
+#
+# XXX: Need review
+#
+XPASS: gcc.dg/tree-ssa/ssa-fre-3.c


### PR DESCRIPTION
This reverts commit 4add4792e6abe4da0aa0ea774b67d524ce23479e.

We currently get some esoteric errors that other people aren't testing for. We should eventually resolve the allowlist's failures, but this should reduce the amount of esoteric regressions we encounter.