### PR TITLE
Add RV23A profile

### DIFF
--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -38,7 +38,7 @@ on:
         - rv64gc_zba_zbb_zbc_zbs-lp64d
         - rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d
         - rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
-        - rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d
+        - rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d
 
 jobs:
   init-submodules:
@@ -138,7 +138,7 @@ jobs:
             rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
             rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d, # rv32 vector crypto
             rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d, # rv64 vector crypto
-            rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d, # RVA23U64 profile with optional extensions
+            rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d, # RVA23U64 profile with optional extensions, excluding unsupported extensions
           ]
         multilib: [non-multilib]
     uses: ./.github/workflows/regression-runner.yaml

--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -38,6 +38,7 @@ on:
         - rv64gc_zba_zbb_zbc_zbs-lp64d
         - rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d
         - rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
+        - rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d
 
 jobs:
   init-submodules:
@@ -137,6 +138,7 @@ jobs:
             rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
             rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d, # rv32 vector crypto
             rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d, # rv64 vector crypto
+            rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d, # RVA23U64 profile with optional extensions
           ]
         multilib: [non-multilib]
     uses: ./.github/workflows/regression-runner.yaml

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -125,6 +125,13 @@ jobs:
           binary-artifact-name: gcc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download linux RVA64U64 profile non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-linux-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # Newlib
       - name: Download newlib rv32 non-multilib
         uses: ./.github/actions/download-comparison-artifacts
@@ -180,6 +187,13 @@ jobs:
         with:
           report-artifact-name: gcc-newlib-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
           binary-artifact-name: gcc-newlib-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d-${{ inputs.gcchash }}-non-multilib
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download newlib RVA64U64 profile non-multilib
+        uses: ./.github/actions/download-comparison-artifacts
+        with:
+          report-artifact-name: gcc-newlib-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Multilib

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -128,8 +128,8 @@ jobs:
       - name: Download linux RVA64U64 profile non-multilib
         uses: ./.github/actions/download-comparison-artifacts
         with:
-          report-artifact-name: gcc-linux-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
-          binary-artifact-name: gcc-linux-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib
+          report-artifact-name: gcc-linux-rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-linux-rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Newlib
@@ -192,8 +192,8 @@ jobs:
       - name: Download newlib RVA64U64 profile non-multilib
         uses: ./.github/actions/download-comparison-artifacts
         with:
-          report-artifact-name: gcc-newlib-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
-          binary-artifact-name: gcc-newlib-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d-${{ inputs.gcchash }}-non-multilib
+          report-artifact-name: gcc-newlib-rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+          binary-artifact-name: gcc-newlib-rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d-${{ inputs.gcchash }}-non-multilib
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Multilib

--- a/.github/workflows/regression-runner.yaml
+++ b/.github/workflows/regression-runner.yaml
@@ -180,7 +180,7 @@ jobs:
           touch -d "+2 days" build-glibc-linux-rv64gcv-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
-          touch -d "+2 days" build-glibc-linux-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d
+          touch -d "+2 days" build-glibc-linux-rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d
           touch -d "+2 days" build-newlib-nano
           touch -d "+2 days" build-${{ inputs.mode }}
           touch -d "+2 days" merge-newlib-nano

--- a/.github/workflows/regression-runner.yaml
+++ b/.github/workflows/regression-runner.yaml
@@ -180,6 +180,7 @@ jobs:
           touch -d "+2 days" build-glibc-linux-rv64gcv-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
+          touch -d "+2 days" build-glibc-linux-rv64mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc-lp64d
           touch -d "+2 days" build-newlib-nano
           touch -d "+2 days" build-${{ inputs.mode }}
           touch -d "+2 days" merge-newlib-nano

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -105,6 +105,12 @@ def aggregate_summary(failures: Dict[str, List[str]], file_name: str):
                     cells[1] = "linux: " + cells[1]
                 else:
                     cells[1] = "newlib: " + cells[1]
+
+                # Apply nicknames
+
+                cells[1] = cells[1].replace("gc_zba_zbb_zbc_zbs", " Bitmanip")
+                cells[1] = cells[1].replace("gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt", " Vector Crypto")
+                cells[1] = cells[1].replace("rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt", "RVA23U64 profile")
                 failures[index].append("|".join(cells))
     return failures
 

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -110,7 +110,7 @@ def aggregate_summary(failures: Dict[str, List[str]], file_name: str):
 
                 cells[1] = cells[1].replace("gc_zba_zbb_zbc_zbs", " Bitmanip")
                 cells[1] = cells[1].replace("gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt", " Vector Crypto")
-                cells[1] = cells[1].replace("rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt", "RVA23U64 profile")
+                cells[1] = cells[1].replace("rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt", "RVA23U64 profile")
                 failures[index].append("|".join(cells))
     return failures
 

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -43,7 +43,8 @@ def get_possible_artifact_names():
         "gc",
         "gcv",
         "gc_zba_zbb_zbc_zbs",
-        "gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt"
+        "gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt",
+        "mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc"
     ]
 
     all_lists = [
@@ -58,6 +59,8 @@ def get_possible_artifact_names():
         name.format(ext, "{}") for name in all_lists for ext in arch_extensions
         if not ("gcv" in ext and "non-multilib" not in name)
         and not ("gc_" in ext and "non-multilib" not in name)
+        and not ("mafdc_" in ext and "non-multilib" not in name)
+        and not ("rv32" in name and "mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc" in ext)
     ]
     return all_names
 

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -44,7 +44,7 @@ def get_possible_artifact_names():
         "gcv",
         "gc_zba_zbb_zbc_zbs",
         "gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt",
-        "mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc"
+        "imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt"
     ]
 
     all_lists = [
@@ -60,7 +60,7 @@ def get_possible_artifact_names():
         if not ("gcv" in ext and "non-multilib" not in name)
         and not ("gc_" in ext and "non-multilib" not in name)
         and not ("mafdc_" in ext and "non-multilib" not in name)
-        and not ("rv32" in name and "mafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zba_zbb_zbs_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_v_zvfhmin_zihintntl_zicond_zcb_zfa_zawrs_zjpm_zfh_zbc_zvfh_zfbfmin_zvfbfwma_zvkng_zvksg_zvbb_zvbc" in ext)
+        and not ("rv32" in name and "imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt" in ext)
     ]
     return all_names
 


### PR DESCRIPTION
This adds the [RV23U64 profile](https://github.com/riscv/riscv-profiles/blob/main/rva23-profile.adoc) and introduces nicknames for configs with long isa strings.