### PR TITLE
Replace project action with dummy code any mark as TODO

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -300,10 +300,8 @@ jobs:
           filename: trimmed_issue.md
           update_existing: true
 
-      - name: Associate issue with project # Only scheduled jobs are guarenteed to track trunk.
+      - name: UNIMPLEMENTED - Associate issue with project # Only scheduled jobs are guarenteed to track trunk.
         if: ${{ github.event_name == 'schedule' }}
-        uses: peter-evans/create-or-update-project-card@v2
-        with:
-          project-name: Trunk-Regressions
-          column-name: No Status
-          issue-number: ${{ steps.create-issue.outputs.number }}
+        run: |
+          echo "Do nothing for now. Most github actions only work with classic projects."
+          echo "We'll likely need to use the API to implement this"


### PR DESCRIPTION
Most (all?) github actions work with classic projects. We'll need to go through the github API to implement this functionality. Leaving the conditional execution and a placeholder to avoid having to figure out that again.