### PR TITLE
Fix bisection regenerated issue no-baseline error when baseline exists

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           rm -rf gcc
           git clone git://gcc.gnu.org/git/gcc.git
-          git submodule update --recursive --progress --recommend-shallow
+          # git submodule update --recursive --progress --recommend-shallow
 
       - name: Pull gcc
         id: gcc-hash

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -50,7 +50,6 @@ jobs:
         run: |
           rm -rf gcc
           git clone git://gcc.gnu.org/git/gcc.git
-          # git submodule update --recursive --progress --recommend-shallow
 
       - name: Pull gcc
         id: gcc-hash
@@ -283,7 +282,6 @@ jobs:
         run: |
           rm -rf gcc
           git clone git://gcc.gnu.org/git/gcc.git
-          git submodule update --recursive --progress --recommend-shallow
 
       - name: Pull gcc
         id: gcc-hash

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -261,6 +261,37 @@ jobs:
               body: 'Bisecting with #${{ needs.generate-issues.outputs.new_issue_num }}'
             })
 
+      - name: Retrieve cache
+        id: retrieve-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .git
+            binutils
+            dejagnu
+            gcc
+            gdb
+            glibc
+            musl
+            newlib
+            pk
+            qemu
+          key: submodules
+
+      - name: Initalize gcc
+        if: steps.retrieve-cache.outputs.cache-hit != 'true'
+        run: |
+          rm -rf gcc
+          git clone git://gcc.gnu.org/git/gcc.git
+          git submodule update --recursive --progress --recommend-shallow
+
+      - name: Pull gcc
+        id: gcc-hash
+        run: |
+          cd gcc
+          git checkout master
+          git pull
+
       - name: Initialize Bisection Hash
         id: bisection-hash
         run: |
@@ -381,7 +412,7 @@ jobs:
       - name: Trim issue length # reduce the number of lines in final issue so github always creates issue
         run: |
           head -c 65000 issue.md > trimmed_issue.md
-          if [ $(cat trimmed_issue.md | wc -l) -ne $(cat issue.md | wc -l) ]; then echo "\`\`\`\nIssue text has been trimmed. Please check logs for the untrimmed issue." >> trimmed_issue.md; fi
+          if [ $(cat trimmed_issue.md | wc -l) -ne $(cat issue.md | wc -l) ]; then echo "\n\`\`\`\nIssue text has been trimmed. Please check logs for the untrimmed issue." >> trimmed_issue.md; fi
           run_id=${{ github.run_id }} && echo "Associated run is: https://github.com/patrick-rivos/riscv-gnu-toolchain/actions/runs/$run_id" >> trimmed_issue.md
           cat trimmed_issue.md
 


### PR DESCRIPTION
[get_most_recent_ci_hash.py](https://github.com/patrick-rivos/riscv-gnu-toolchain/blob/build-frequent/scripts/get_most_recent_ci_hash.py) was encountering an error where it could not retrieve the 100 most recent commits due to an error with the tree. Pull the most updated version of gcc in the regenerate summary to fix

Test: https://github.com/ewlu/riscv-gnu-toolchain/actions/runs/6006001115/job/16307721347?pr=41
Regenerate: https://github.com/patrick-rivos/riscv-gnu-toolchain/actions/runs/6017124614