### PR TITLE
Build singlelib targets with multilib-generator

### DIFF
--- a/.github/dockerfile/configure.sh
+++ b/.github/dockerfile/configure.sh
@@ -6,5 +6,5 @@ if [ "$1" == "multilib" ]; then
 else
   TARGET_TUPLE=($(echo $2 | tr "-" "\n"))
   cd tc && cd build && ../configure --prefix=/tc/build \
-    --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]};
+    --with-multilib-generator="${TARGET_TUPLE[0]}-${TARGET_TUPLE[1]}--"
 fi

--- a/.github/workflows/regression-runner.yaml
+++ b/.github/workflows/regression-runner.yaml
@@ -81,10 +81,10 @@ jobs:
           mkdir build
           cd build
           if [ "${{ inputs.multilib }}" == "multilib" ]; then
-            ../configure --prefix=$(pwd) --enable-multilib --with-multilib-generator="rv64gc-lp64d--;rv32gc-ilp32d--"
+            ../configure --prefix=$(pwd) --with-multilib-generator="rv64gc-lp64d--;rv32gc-ilp32d--"
           else
             TARGET_TUPLE=($(echo ${{ inputs.target }} | tr "-" "\n"))
-            ../configure --prefix=$(pwd) --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
+            ../configure --prefix=$(pwd) --with-multilib-generator="${TARGET_TUPLE[0]}-${TARGET_TUPLE[1]}--"
           fi
 
       - name: Make gcc
@@ -177,7 +177,7 @@ jobs:
             ../configure --prefix=$(pwd) --with-multilib-generator="rv64gc-lp64d--;rv32gc-ilp32d--"
           else
             TARGET_TUPLE=($(echo ${{ inputs.target }} | tr "-" "\n"))
-            ../configure --prefix=$(pwd) --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
+            ../configure --prefix=$(pwd) --with-multilib-generator="${TARGET_TUPLE[0]}-${TARGET_TUPLE[1]}--"
           fi
 
       - name: Restore stage2
@@ -314,7 +314,7 @@ jobs:
             ../configure --prefix=$(pwd) --with-multilib-generator="rv64gc-lp64d--;rv32gc-ilp32d--"
           else
             TARGET_TUPLE=($(echo ${{ inputs.target }} | tr "-" "\n"))
-            ../configure --prefix=$(pwd) --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
+            ../configure --prefix=$(pwd) --with-multilib-generator="${TARGET_TUPLE[0]}-${TARGET_TUPLE[1]}--"
           fi
 
       - name: Build
@@ -404,7 +404,7 @@ jobs:
             ../configure --prefix=$(pwd) --with-multilib-generator="rv64gc-lp64d--;rv32gc-ilp32d--"
           else
             TARGET_TUPLE=($(echo ${{ inputs.target }} | tr "-" "\n"))
-            ../configure --prefix=$(pwd) --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
+            ../configure --prefix=$(pwd) --with-multilib-generator="${TARGET_TUPLE[0]}-${TARGET_TUPLE[1]}--"
           fi
 
       - name: Build


### PR DESCRIPTION
This will allow us to sidestep stubs.h failures.