### PR TITLE
Change cadence to twice a day to allow other repo to get started

### DIFF
--- a/.github/workflows/build-frequent.yaml
+++ b/.github/workflows/build-frequent.yaml
@@ -8,8 +8,8 @@ on:
     branches:
       - build-frequent
   schedule:
-    # Run 4 times a day
-    - cron: 0 0,6,12,18 * * *
+    # Run 2 times a day
+    - cron: 0 0,12 * * *
   workflow_dispatch:
     branches:
       - build-frequent


### PR DESCRIPTION
Corresponds with this line in the other repo: https://github.com/patrick-rivos/gcc-postcommit-ci/blob/main/.github/workflows/run-frequent.yaml#L13