### PR TITLE
bump qemu to v8.2.0 for vector crypto support and add ext opt to march-to-cpu-opt

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -13,14 +13,15 @@ EXT_OPTS = {
   "zbc":             "zbc=true",
   "zbs":             "zbs=true",
   "v":               "v=true,vext_spec=v1.0",
-  "zve32f":          "Zve32f=true",
-  "zve64f":          "Zve64f=true",
-  "zfh":             "Zfh=true",
-  "zfhmin":             "Zfhmin=true",
+  "zve32f":          "zve32f=true",
+  "zve64f":          "zve64f=true",
+  "zfh":             "zfh=true",
+  "zfhmin":             "zfhmin=true",
   "zhinx":           "zhinx=true",
   "zfinx":           "zfinx=true",
   "zdinx":           "zdinx=true",
-  "zicond":          "x-zicond=true",
+  "zicond":          "zicond=true",
+  "zvbb":            "zvbb=true",
 }
 
 SUPPORTTED_EXTS = "iemafdcbvph"


### PR DESCRIPTION
version commit: https://github.com/qemu/qemu/commit/f48c205fb42be48e2e47b7e1cd9a2802e5ca17b0
`Zve*` being deprecated in favor of `zve*` and same for `Zfh*`