### PR TITLE
add more info to get previous timestamp assertion by printing out the 10 most recent runs

### DIFF
--- a/scripts/get_previous_timestamp.py
+++ b/scripts/get_previous_timestamp.py
@@ -59,7 +59,7 @@ def write_run_timestamp(runs, run_id: str):
 
 def write_run_id(runs, run_id: str):
     assert(len(runs) >= 1)
-    assert(str(runs[0]['id']) == str(run_id)), f"The 10 most recent runs are: \n{runs[:10]}"
+    assert str(runs[0]['id']) == str(run_id), f"The 10 most recent runs are: \n{runs[:10]}"
     with open("run_id.txt", "w") as f:
         f.write(str(runs[1]['id']))
 


### PR DESCRIPTION
tested with: `python -c "a=[1,2,3,4,5,6,7,8,9]; assert(False), f'3 recent runs:\n{a[:3]}'"`
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError: 3 recent runs:
[1, 2, 3]
```