### PR TITLE
fix weekly runner comparisons 

### DIFF
--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -35,6 +35,14 @@ def parse_arguments():
         type=str,
         help="Github access token",
     )
+    parser.add_argument(
+        "-prefix",
+        required=False,
+        default="",
+        type=str,
+        help="Artifact prefix",
+    )
+
     return parser.parse_args()
 
 
@@ -61,7 +69,7 @@ def get_valid_artifact_hash(
     return "No valid hash", None
 
 
-def get_possible_artifact_names() -> List[str]:
+def get_possible_artifact_names(prefix: str) -> List[str]:
     """
     Generates all possible permutations of target artifact logs and
     removes unsupported targets
@@ -71,7 +79,7 @@ def get_possible_artifact_names() -> List[str]:
       Newlib: rv32/64 non-multilib
       Arch extensions: gc
     """
-    libc = ["gcc-linux", "gcc-newlib"]
+    libc = [f"{prefix}gcc-linux", f"{prefix}gcc-newlib"]
     arch = ["rv32{}-ilp32d-{}", "rv64{}-lp64d-{}"]
 
     multilib_arch_extensions = [
@@ -178,7 +186,7 @@ def issue_hashes(repo_name: str, token: str):
     return hashes
 
 def download_all_artifacts(
-    current_hash: str, previous_hash: str, repo_name: str, token: str
+    current_hash: str, previous_hash: str, repo_name: str, token: str, prefix: str
 ):
     """
     Goes through all possible artifact targets and downloads it
@@ -247,7 +255,7 @@ def download_all_artifacts(
 
 def main():
     args = parse_arguments()
-    download_all_artifacts(args.hash, args.phash, args.repo, args.token)
+    download_all_artifacts(args.hash, args.phash, args.repo, args.token, args.prefix)
 
 
 if __name__ == "__main__":

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -200,7 +200,7 @@ def download_all_artifacts(
     # sort most recent issue commit hashes by topological order
     prev_commits = gcc_hashes(current_hash, issue_commits)
 
-    artifact_name_templates = get_possible_artifact_names()
+    artifact_name_templates = get_possible_artifact_names(prefix)
     # TODO: Refactor this block
     for artifact_name_template in artifact_name_templates:
         artifact = artifact_name_template.format(current_hash)


### PR DESCRIPTION
All runners use `download_artifacts.py` to pull the previous log artifacts. `download_artifacts.py` assumes no prefixes which results in never finding a previous logs for weekly runners since all weekly runner artifacts are prefixed.