### PR TITLE
have separate branches for weekly run possible names

### DIFF
--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -82,22 +82,45 @@ def get_possible_artifact_names(prefix: str) -> List[str]:
     libc = [f"{prefix}gcc-linux", f"{prefix}gcc-newlib"]
     arch = ["rv32{}-ilp32d-{}", "rv64{}-lp64d-{}"]
 
+    multilib_arch_extensions = None
+    multilib_lists = None
+
     # Weekly arch extensions included since rv64gcv_zv* doesn't
     # exist without a prefix
-    multilib_arch_extensions = [
-        "gcv",
-        "gcv_zve64d",
-        "gcv_zvl1024b",
-        "gcv_zvl512b",
-        "gcv_zvl256b",
-    ]
+    if prefix == "":
+        multilib_arch_extensions = [
+            "gcv",
+        ]
 
-    # now have weekly runners rv32 zvl multilib variants
-    multilib_lists = [
-        "-".join([i, j, "multilib"])
-        for i in libc
-        for j in arch
-    ]
+        multilib_lists = [
+            "-".join([i, j, "multilib"])
+            for i in libc
+            for j in arch
+            if "rv64" in j
+        ]
+    else:
+        possible_arch_extensions = [
+            "gcv_zve64d",
+            "gcv_zvl1024b",
+            "gcv_zvl512b",
+            "gcv_zvl256b",
+        ]
+        # each extension ends in '_'. Use this since lmul extensions
+        # use the same arch extension but the prefix is
+        # currently structured as zvl_lmulx_ 
+        prefix = prefix.split('_')[0]
+        multilib_arch_extensions = [
+            ext
+            for ext in possible_arch_extensions
+            if prefix in ext
+        ]
+
+        # now have weekly runners rv32 zvl multilib variants
+        multilib_lists = [
+            "-".join([i, j, "multilib"])
+            for i in libc
+            for j in arch
+        ]
 
     multilib_names = [
         name.format(ext, "{}")


### PR DESCRIPTION
 `download_artifacts.py` label which builds fail by checking if the build artifact exists https://github.com/patrick-rivos/riscv-gnu-toolchain/blob/build-frequent/scripts/download_artifacts.py#L138-L144. The previous implementation generated the minimal subset of possible arch combinations. Adding weekly build arch extensions in 3fdf1f389f682f49db66dea1675abdc35917d1ca caused false `build-failure` labels to be generated since it would not be able to find the weekly build arches when `prefix == ''`. Separating the possible arch extensions into different branches should allow the regular daily runs to be `build-failure` free (unless a real build failure occurs).