### PR TITLE
Produce a git log after applying the patches

### DIFF
--- a/scripts/generate_apply_report.py
+++ b/scripts/generate_apply_report.py
@@ -1,5 +1,5 @@
 import argparse
-import re
+import subprocess
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Apply patch report generator")
@@ -62,6 +62,16 @@ def build_status(bhash:str, thash: str, bstatus: str, tstatus: str):
     result += f"|Tip of tree hash: {thash}|{tstatus}|\n"
     return result
 
+def git_log_since_hash(hash: str):
+    result = "## Git log\n"
+    result += "git log --oneline from the most recently applied patch to the baseline\n"
+    result += "```\n"
+    result += f"> git log --oneline {hash}^..HEAD\n"
+    git_log = subprocess.run(['git', '-C', 'gcc', 'log', '--oneline', f'{hash}^..HEAD'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    result += git_log.stdout.decode('utf-8')
+    result += "```\n\n"
+    return result
+
 def generate_report(patch_name: str, bhash: str, thash: str, bstatus: str, tstatus: str):
     result = ""
     if bstatus != "pending":
@@ -83,6 +93,7 @@ def generate_report(patch_name: str, bhash: str, thash: str, bstatus: str, tstat
             result += f.read()
         result += "```"
     elif bstatus == "Failed" and tstatus == "Applied":
+        result += git_log_since_hash(thash)
         result += "## Notes\n"
         result += f"""Failed to apply to the [post-commit baseline](https://github.com/patrick-rivos/gcc-postcommit-ci/issues?q=is%3Aissue+{bhash}). This can happen
 if your commit requires a recently-commited patch in order to apply.
@@ -94,12 +105,14 @@ different hash, please email us at patchworks-ci@rivosinc.com with a link
 to your patch.
 """
     elif bstatus == "Applied" and tstatus == "Failed":
+        result += git_log_since_hash(bhash)
         result += "## Notes\n"
         result += """Failed to apply to tip-of-tree. The patch will still
 be tested against the baseline hash. A rebase may be necessary
 before merging.
 """
     else:
+        result += git_log_since_hash(bhash)
         result += "## Notes\n"
         result += "Patch applied successfully"
 


### PR DESCRIPTION
This adds a section to the precommit apply step that looks like this:

## Git log
git log --oneline from the most recently applied patch to the baseline
```
> git log --oneline 1588983be61^..HEAD
89349e6a099 Cleanup whitespace in target-supports.exp
1588983be61 RISC-V: Add Zalrsc amo-op patterns
```