### PR TITLE
Generate seperate log files and select at runtime

### DIFF
--- a/scripts/generate_apply_report.py
+++ b/scripts/generate_apply_report.py
@@ -61,6 +61,16 @@ def build_status(bhash:str, thash: str, bstatus: str, tstatus: str):
     result += f"|Tip of tree hash: {thash}|{tstatus}|\n"
     return result
 
+def git_log_wrapper(logfile: str):
+    result = "## Git log\n"
+    result += "git log --oneline from the most recently applied patch to the baseline\n"
+    result += "```\n"
+    result += f"> git log --oneline {hash}^..HEAD\n"
+    with open(logfile, "r") as f:
+        result += f.read()
+    result += "```\n\n"
+    return result
+
 def generate_report(patch_name: str, bhash: str, thash: str, bstatus: str, tstatus: str):
     result = ""
     if bstatus != "pending":
@@ -82,8 +92,7 @@ def generate_report(patch_name: str, bhash: str, thash: str, bstatus: str, tstat
             result += f.read()
         result += "```"
     elif bstatus == "Failed" and tstatus == "Applied":
-        with open("gcc/git_log_tot.txt", "r") as f:
-            result += f.read()
+        git_log_wrapper("gcc/git_log_tot.txt")
         result += "## Notes\n"
         result += f"""Failed to apply to the [post-commit baseline](https://github.com/patrick-rivos/gcc-postcommit-ci/issues?q=is%3Aissue+{bhash}). This can happen
 if your commit requires a recently-commited patch in order to apply.
@@ -95,16 +104,14 @@ different hash, please email us at patchworks-ci@rivosinc.com with a link
 to your patch.
 """
     elif bstatus == "Applied" and tstatus == "Failed":
-        with open("gcc/git_log_bl.txt", "r") as f:
-            result += f.read()
+        git_log_wrapper("gcc/git_log_bl.txt")
         result += "## Notes\n"
         result += """Failed to apply to tip-of-tree. The patch will still
 be tested against the baseline hash. A rebase may be necessary
 before merging.
 """
     else:
-        with open("gcc/git_log_bl.txt", "r") as f:
-            result += f.read()
+        git_log_wrapper("gcc/git_log_bl.txt")
         result += "## Notes\n"
         result += "Patch applied successfully"
 

--- a/scripts/generate_apply_report.py
+++ b/scripts/generate_apply_report.py
@@ -1,5 +1,4 @@
 import argparse
-import subprocess
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Apply patch report generator")
@@ -62,16 +61,6 @@ def build_status(bhash:str, thash: str, bstatus: str, tstatus: str):
     result += f"|Tip of tree hash: {thash}|{tstatus}|\n"
     return result
 
-def git_log_since_hash(hash: str):
-    result = "## Git log\n"
-    result += "git log --oneline from the most recently applied patch to the baseline\n"
-    result += "```\n"
-    result += f"> git log --oneline {hash}^..HEAD\n"
-    git_log = subprocess.run(['git', '-C', 'gcc', 'log', '--oneline', f'{hash}^..HEAD'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    result += git_log.stdout.decode('utf-8')
-    result += "```\n\n"
-    return result
-
 def generate_report(patch_name: str, bhash: str, thash: str, bstatus: str, tstatus: str):
     result = ""
     if bstatus != "pending":
@@ -93,7 +82,8 @@ def generate_report(patch_name: str, bhash: str, thash: str, bstatus: str, tstat
             result += f.read()
         result += "```"
     elif bstatus == "Failed" and tstatus == "Applied":
-        result += git_log_since_hash(thash)
+        with open("gcc/git_log_tot.txt", "r") as f:
+            result += f.read()
         result += "## Notes\n"
         result += f"""Failed to apply to the [post-commit baseline](https://github.com/patrick-rivos/gcc-postcommit-ci/issues?q=is%3Aissue+{bhash}). This can happen
 if your commit requires a recently-commited patch in order to apply.
@@ -105,14 +95,16 @@ different hash, please email us at patchworks-ci@rivosinc.com with a link
 to your patch.
 """
     elif bstatus == "Applied" and tstatus == "Failed":
-        result += git_log_since_hash(bhash)
+        with open("gcc/git_log_bl.txt", "r") as f:
+            result += f.read()
         result += "## Notes\n"
         result += """Failed to apply to tip-of-tree. The patch will still
 be tested against the baseline hash. A rebase may be necessary
 before merging.
 """
     else:
-        result += git_log_since_hash(bhash)
+        with open("gcc/git_log_bl.txt", "r") as f:
+            result += f.read()
         result += "## Notes\n"
         result += "Patch applied successfully"
 


### PR DESCRIPTION
The gcc tree is in the applied-to-tip-of-tree state when this script is run. We need to collect the git log files before this is script is run and select the relevant one when this is run.