### PR TITLE
Modify download_artifact.py for possible break in python 3.8

### DIFF
--- a/scripts/download_artifact.py
+++ b/scripts/download_artifact.py
@@ -109,7 +109,7 @@ def extract_artifact(artifact_zip: str, outdir: str = "current_logs"
         output_dir_path.mkdir(parents=True, exist_ok=True)
         # Move all the files/directory unzipped from the artifact
         for file in artifact_path.iterdir():
-            move(file, outdir)
+            move(str(file), outdir)
 
 
 def main():


### PR DESCRIPTION
Shutil.move has a bug in python3.8 where using path as a parameter doesn't resolve the path correctly. Instead of directly passing path as an argument, pass string