### PR TITLE
Build log download feature for download_artifacts

### DIFF
--- a/.github/workflows/pre-pull-request.yaml
+++ b/.github/workflows/pre-pull-request.yaml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest test/pytests
+          pytest test/pytests --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/get_baseline_hash.py
+++ b/scripts/get_baseline_hash.py
@@ -26,7 +26,7 @@ def filter_results(issue):
     if 'pull_request' not in issue.keys() and labels_check and title_check:
         return True
 
-def parse_baseline_hash(url: str, token: str):
+def parse_baseline_hash(url: str, token: str)->str:
     params = {"Accept": "application/vnd.github+json",
               "Authorization": f"token {token}",
               "X-GitHub-Api-Version": "2022-11-28"}
@@ -36,8 +36,10 @@ def parse_baseline_hash(url: str, token: str):
     issue = filtered[0]
     print(f"Baseline from {issue['title']}")
     assert(re.search("^Testsuite Status [0-9a-f]{40}$", issue["title"]) is not None) # re.search returns None if pattern not found
+    baseline_hash = issue["title"].split(" ")[-1]
     with open("./baseline.txt", "w") as f:
-        f.write(issue["title"].split(" ")[-1])
+        f.write(baseline_hash)
+    return baseline_hash
 
 def main():
     args = parse_arguments()

--- a/test/pytests/conftest.py
+++ b/test/pytests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--github-token",
+        action="store",
+        type=str,
+        help="Github token value for github api testing"
+    )
+
+@pytest.fixture
+def github_token(request):
+    return request.config.getoption("--github-token")
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "github_token_required: Mark test as requiring the github token"
+    )
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--github-token"):
+        # If the option is set, do nothing (run all tests)
+        return
+    # skip github token required tests if github token isn't specified
+    skip_option = pytest.mark.skip(reason="Requires github token")
+    for item in items:
+        if "github_token_required" in item.keywords:
+            item.add_marker(skip_option)

--- a/test/pytests/test_scripts/test_download_artifacts.py
+++ b/test/pytests/test_scripts/test_download_artifacts.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+import pytest
+
+scripts_path = Path(__file__).parent.parent.parent.parent / "scripts"
+sys.path.append(str(scripts_path))
+from download_artifacts import download_build_log_artifact
+from get_baseline_hash import parse_baseline_hash
+
+@pytest.fixture
+@pytest.mark.github_token_required
+def base_hash(github_token):
+    url = "https://api.github.com/repos/patrick-rivos/gcc-postcommit-ci/issues?state=all&per_page=50"
+    base_hash = parse_baseline_hash(url, github_token)
+    return base_hash
+
+
+@pytest.mark.github_token_required
+def test_download_build_log_artifact(base_hash, github_token):
+    print(f"Base hash: {base_hash}")
+    with TemporaryDirectory() as tmp_dir:
+        target = "newlib-rv64gc-lp64d"
+        template = target + "-{}-non-multilib"
+        # find base hash
+        download_build_log_artifact(template, base_hash , "patrick-rivos/gcc-postcommit-ci", github_token, tmp_dir)
+        build_log_files = [file for file in Path(tmp_dir).iterdir()]
+        print(build_log_files)
+        BUILD_LOG_FILE_NUM = 1
+        assert(len(build_log_files) == BUILD_LOG_FILE_NUM)
+        EXPECTED_ZIP_NAME = template.format(base_hash) + "-build-log.zip"
+        assert(Path(build_log_files[0]).name == EXPECTED_ZIP_NAME)


### PR DESCRIPTION
After the discussion with @patrick-rivos and @ewlu, downloading the build log artifacts feature is decided to reside in download_artifacts.py. 
1. download_artifacts.py now first searches for the report artifact to determine the correct base hash for the given target template. Then the base hash could be used to download other artifacts
2. --build-logs option enables the build log artifact download. --build-logs-dir option is used to pass the build logs artifact destination. If it's not specified while --build-logs is enabled, it defaults to previous_build_logs directory.
3. Pytest for download_build_logs_artifact function is added to check a proper download. conftest.py is created to take github token as input since github api call is required for this test. If the github token is not specified, marker github_token_required lets it skip the test automatically.