### PR TITLE
add 128b as potential weekly build

### DIFF
--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -98,6 +98,7 @@ def get_weekly_names(prefix: str) -> List[str]:
         "gcv_zvl1024b",
         "gcv_zvl512b",
         "gcv_zvl256b",
+        "gcv_zvl128b",
     ]
     # each extension ends in '_'. Use this since lmul extensions
     # use the same arch extension but the prefix is


### PR DESCRIPTION
weekly runner lmul=2 always has `no-baseline` for the `gcv_zvl128b` target since it's not considered a potential downloadable target. This was done because the weekly runner without specifying lmul by default is tested in frequent runners as `rv64gcv`.