### PR TITLE
Sort by target when emitting warnings

### DIFF
--- a/scripts/parse_new_build_warnings.py
+++ b/scripts/parse_new_build_warnings.py
@@ -168,7 +168,7 @@ def export_build_warnings(warnings_dict: Dict[str, Set[str]], output: str):
         f.write(
             f"# New build warnings\nA List of all additional build warnings present at this hash\n"
         )
-        for target, warnings in warnings_dict.items():
+        for target, warnings in sorted(warnings_dict.items(), key=lambda item: item[0]):
             if not warnings:
                 continue
             f.write(f"## {target}\n```\n")


### PR DESCRIPTION
This'll be helpful to see if there are warnings we aren't deduplicating