### PR TITLE
fix(create_gist): return correct html_rul instead of the api result url

### DIFF
--- a/scripts/create_gist.py
+++ b/scripts/create_gist.py
@@ -55,7 +55,7 @@ def create_gist(input_file: str, token: str) -> str:
     gist = auth_user.create_gist(
         public=False, files={input_file: InputFileContent(content=input_contents)}
     )
-    return gist.url
+    return gist.html_url
 
 
 def write_url(url: str, output_file: str):


### PR DESCRIPTION
The original url is a pure api response url in json forma. html url with proper ui is the one we need for visualization.