### PR TITLE
Create new option title to specify a displayed file name that is different from the original file name

### DIFF
--- a/scripts/create_gist.py
+++ b/scripts/create_gist.py
@@ -2,6 +2,7 @@ import argparse
 
 from github import Github, InputFileContent
 from pathlib import Path
+from typing import Optional
 
 
 def parse_arguments():
@@ -20,6 +21,12 @@ def parse_arguments():
         help="Path to the outputfile that would contain the created gist url",
     )
     parser.add_argument(
+        "--title",
+        required=False,
+        type=str,
+        help="File name to be displayed in the uploaded gist",
+    )
+    parser.add_argument(
         "--token",
         required=True,
         type=str,
@@ -28,7 +35,7 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def create_gist(input_file: str, token: str) -> str:
+def create_gist(input_file: str, token: str, title: Optional[str] = None) -> str:
     """
     Creates a private GitHub Gist from the contents of the specified input file.
     The URL of the created Gist is returned.
@@ -49,11 +56,11 @@ def create_gist(input_file: str, token: str) -> str:
         raise RuntimeError(f"Input file {input_file} doesn't exist")
 
     input_contents = input_path.read_text(encoding="utf-8")
-
+    input_file_title = title.replace(" ", "_") if title else input_file
     github = Github(token)
     auth_user = github.get_user()
     gist = auth_user.create_gist(
-        public=False, files={input_file: InputFileContent(content=input_contents)}
+        public=False, files={input_file_title: InputFileContent(content=input_contents)}
     )
     return gist.html_url
 
@@ -68,7 +75,7 @@ def write_url(url: str, output_file: str):
 
 def main():
     args = parse_arguments()
-    url = create_gist(args.input, args.token)
+    url = create_gist(args.input, args.token, args.title)
     write_url(url, args.output)
 
 


### PR DESCRIPTION
Provide a option to customize the uploaded gist file's name. 

The script replaces ' ' with '_' to pass in a valid file name.