### PR TITLE
update weekly build targets

### DIFF
--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -108,6 +108,7 @@ def get_weekly_names(prefix: str) -> List[str]:
     # each extension ends in '_'. Use this since lmul extensions
     # use the same arch extension but the prefix is
     # currently structured as rvx_zvl_lmulx_
+    is_lmul_prefix = "lmul" in prefix
     comps = prefix.split("_")
     prefix_arch = ""
 
@@ -117,9 +118,20 @@ def get_weekly_names(prefix: str) -> List[str]:
         prefix = comps[1]
         prefix_arch = comps[0]
 
-    multilib_arch_extensions = [
-        ext for ext in possible_arch_extensions if prefix in ext
-    ]
+    if is_lmul_prefix:
+        multilib_arch_extensions = [
+            ext for ext in possible_arch_extensions if prefix in ext
+        ]
+    else:
+        # Non lmul zvl runs do not run 128 since that's the default and is
+        # caught by the run-frequent runs. However, it would cause a false
+        # build-failure on the zvl runs because it can't find the gcv_zvl128b
+        # binary
+        multilib_arch_extensions = [
+            ext
+            for ext in possible_arch_extensions
+            if prefix in ext and "128" not in ext
+        ]
     print("prefix arch:", prefix_arch)
 
     # now have weekly runners rv32 zvl multilib variants

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -88,7 +88,12 @@ def get_weekly_names(prefix: str) -> List[str]:
     zve_
     rvx_zvl_
     rvx_zvl_lmulx_
+    checking_
     """
+
+    if prefix == "checking_":
+        return ["checking_gcc-linux-rv64gcv_zicond-lp64d-{}-multilib"]
+
     # don't test newlib with weekly runs
     libc = [f"{prefix}gcc-linux"]
     arch = ["rv32{}-ilp32d-{}", "rv64{}-lp64d-{}"]


### PR DESCRIPTION
For adding weekly runner build with checking. The target `rv64gcv_zicond` was chosen arbitrarily to distinguish it from all the other gcv targets since it won't actually be running rv64gcv but the rva23 profile. If anyone wants to change it, I have no preference over the naming scheme