### PR TITLE
Fix download_artifacts script's build log format

### DIFF
--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -372,7 +372,7 @@ def download_build_log_artifact(
         print("Missing base hash, skipping downloading the build log artifact")
         return
 
-    target_format_pat = re.compile(r"^gcc-")
+    target_format_pat = re.compile(r"gcc-")
     BUILD_LOG_SUFFIX = "-build-log"
     # Remove the starting gcc- and concatenate with the suffix
     artifact_name = target_format_pat.sub(


### PR DESCRIPTION
The `^gcc-` regex prevented the script from downloading the build logs with prefix. The string doesn't start with `gcc-` if prefix is appended, so remove the `^` to succesfully remove any `gcc-` in the string. 
