### PR TITLE
Empty Build Warnings export

### DIFF
--- a/scripts/parse_new_build_warnings.py
+++ b/scripts/parse_new_build_warnings.py
@@ -164,10 +164,23 @@ def parse_new_build_warnings_from_directory(
 
 
 def export_build_warnings(warnings_dict: Dict[str, Set[str]], output: str):
+    """Export the build warnings to a specified output file
+    Simply print New build warnings doesn't exist if warnings_dict is empty
+    """
+
+    def is_warnings_dict_empty(warnings_dict: Dict[str, Set[str]]):
+        for _, warnings in warnings_dict.items():
+            if warnings:
+                return False
+            return True
+
     with open(output, "w") as f:
-        f.write(
-            f"# New build warnings\nA List of all additional build warnings present at this hash\n"
-        )
+        if is_warnings_dict_empty(warnings_dict):
+            comment = "New build warnings doesn't exist"
+            f.write(comment)
+            return
+        comment = "# New build warnings\nA List of all additional build warnings present at this hash\n"
+        f.write(comment)
         for target, warnings in sorted(warnings_dict.items()):
             if not warnings:
                 continue

--- a/test/pytests/test_scripts/test_parse_new_build_warnings.py
+++ b/test/pytests/test_scripts/test_parse_new_build_warnings.py
@@ -7,7 +7,7 @@ import sys
 scripts_path = Path(__file__).parent.parent.parent.parent / "scripts"
 sys.path.append(str(scripts_path))
 
-from parse_new_build_warnings import parse_new_build_warnings, construct_warning_set, parse_new_build_warnings_from_directory, parse_target, POST_COMMIT, PRE_COMMIT
+from parse_new_build_warnings import parse_new_build_warnings, construct_warning_set, parse_new_build_warnings_from_directory, parse_target, POST_COMMIT, PRE_COMMIT, export_build_warnings
 
 @pytest.fixture
 def build_warning_string_1()->str:
@@ -155,8 +155,6 @@ def test_pre_commit_parse_new_build_warnings_from_directory(build_warnings_direc
         print("\n\nnew_warnings: ", new_warnings[target])
         assert(new_warnings[target] == warning_set)
 
-
-
 def test_post_commit_parse_new_build_warnings_from_directory(build_warnings_directory_1, build_warnings_directory_2):
     old_build_dir, old_a, old_b = build_warnings_directory_1
     new_build_dir, _, _ = build_warnings_directory_2
@@ -182,3 +180,17 @@ def test_post_commit_parse_new_build_warnings_from_directory(build_warnings_dire
         print("expected: ", warning_set)
         print("\n\nnew_warnings: ", new_warnings[target])
         assert(new_warnings[target] == warning_set)
+
+def test_export_empty_build_warnings():
+    empty_warnings_dict = {"foo": set()}
+    with NamedTemporaryFile() as tmp:
+        export_build_warnings(empty_warnings_dict, tmp.name)
+        with open(tmp.name, 'r') as f:
+            assert(f.read() == "New build warnings doesn't exist")
+
+def test_export_build_warnings():
+    warnings_dict = {"foo": set("bar\n")}
+    with NamedTemporaryFile() as tmp:
+        export_build_warnings(warnings_dict, tmp.name)
+        with open(tmp.name, 'r') as f:
+            assert(f.readline() == "# New build warnings\n")


### PR DESCRIPTION
Originally, even if the new build warnings dictionary is empty, it printed out the header to the output log file. This is not only misleading but also fails to provide any hint to other scripts about the presence of new build warnings.

Not printing out the log at all to the file or not creating the file could be confusing since some ambiguous error might have occurred.

Instead, if there weren't an additional build warnings, simply print out `New build warnings doesn't exist` for clarification.
