### PR TITLE
Build warnings delta

### DIFF
--- a/test/pytests/test_scripts/test_parse_new_build_warnings.py
+++ b/test/pytests/test_scripts/test_parse_new_build_warnings.py
@@ -7,7 +7,7 @@ import sys
 scripts_path = Path(__file__).parent.parent.parent.parent / "scripts"
 sys.path.append(str(scripts_path))
 
-from parse_new_build_warnings import parse_new_build_warnings, construct_warning_set, parse_new_build_warnings_from_directory, parse_target, POST_COMMIT, PRE_COMMIT, export_build_warnings
+from parse_build_warnings import parse_build_warnings, construct_warning_set, parse_build_warnings_from_directory, parse_target, POST_COMMIT, PRE_COMMIT, export_build_warnings
 
 @pytest.fixture
 def build_warning_string_1()->str:
@@ -38,6 +38,9 @@ In file included from ../../../gcc/gcc/analyzer/access-diagram.cc:35:
 @pytest.fixture
 def build_warning_string_3()->str:
     return '''libtool: install: warning: remember to run `libtool --finish /home/runner/work/gcc-postcommit-ci/gcc-postcommit-ci/riscv-gnu-toolchain/build/libexec/gcc/riscv64-unknown-linux-gnu/15.0.0'                    ^
+../../../gcc/gcc/analyzer/analyzer.cc:248:25: warning: unknown conversion type character ‘@’ in format [-Wformat=]
+  248 |       pp_printf (&pp, "%@", &event_id);
+      |
 
 '''
 
@@ -124,23 +127,24 @@ def test_construct_warning_set_2(build_warning_2):
     expected ={'../../../gcc/gcc/analyzer/analyzer.cc:248:25: warning: unknown conversion type character ‘@’ in format [-Wformat=]\n  248 |       pp_printf (&pp, "%@", &event_id);\n      |                         ^\n', '../../../gcc/gcc/analyzer/access-diagram.cc:1509:35: warning: unknown conversion type character ‘@’ in format [-Wformat=]\n 1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),\n../../../gcc/gcc/intl.h:40:26: note: in definition of macro ‘gettext’\n   40 | # define gettext(msgid) (msgid)\n      |                          ^~~~~\n../../../gcc/gcc/analyzer/access-diagram.cc:1509:33: note: in expansion of macro ‘_’\n 1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),\n      |                                 ^\n'}
     assert(warning_set == expected)
 
-def test_parse_new_build_warnings(build_warning_1, build_warning_2):
-    warning_set = parse_new_build_warnings(build_warning_1, build_warning_2)
+def test_parse_build_warnings(build_warning_1, build_warning_2):
+    new_warnings, resolved_warnings = parse_build_warnings(build_warning_1, build_warning_2)
     expected = {'../../../gcc/gcc/analyzer/access-diagram.cc:1509:35: warning: unknown conversion type character ‘@’ in format [-Wformat=]\n 1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),\n../../../gcc/gcc/intl.h:40:26: note: in definition of macro ‘gettext’\n   40 | # define gettext(msgid) (msgid)\n      |                          ^~~~~\n../../../gcc/gcc/analyzer/access-diagram.cc:1509:33: note: in expansion of macro ‘_’\n 1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),\n      |                                 ^\n'}
-    assert(warning_set == expected)
+    assert(new_warnings == expected)
+    assert(resolved_warnings == set())
 
-def test_pre_commit_parse_new_build_warnings_from_directory(build_warnings_directory_1, build_warnings_directory_3):
+def test_pre_commit_parse_build_warnings_from_directory(build_warnings_directory_1, build_warnings_directory_3):
     old_build_dir, old_a, old_b = build_warnings_directory_1
     new_build_dir, _, _ = build_warnings_directory_3
     a_target = parse_target(old_a.name)
     b_target = parse_target(old_b.name)
 
-    expected = {a_target:set(), b_target: set()}
-    expected[b_target].add("../Rules:360: warning: overriding recipe for target 'riscv-gnu-toolchain/build/build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d/string/tst-strerror.out'\n")
-    expected[b_target].add('''plural.y:52.1-7: warning: POSIX Yacc does not support %expect [-Wyacc]
+    new_expected = {a_target:set(), b_target: set()}
+    new_expected[b_target].add("../Rules:360: warning: overriding recipe for target 'riscv-gnu-toolchain/build/build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d/string/tst-strerror.out'\n")
+    new_expected[b_target].add('''plural.y:52.1-7: warning: POSIX Yacc does not support %expect [-Wyacc]
    52 | %expect 7
       | ^~~~~~~\n''')
-    expected[a_target].add('''../../../gcc/gcc/analyzer/access-diagram.cc:1509:35: warning: unknown conversion type character ‘@’ in format [-Wformat=]
+    new_expected[a_target].add('''../../../gcc/gcc/analyzer/access-diagram.cc:1509:35: warning: unknown conversion type character ‘@’ in format [-Wformat=]
  1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),
 ../../../gcc/gcc/intl.h:40:26: note: in definition of macro ‘gettext’
    40 | # define gettext(msgid) (msgid)
@@ -148,14 +152,22 @@ def test_pre_commit_parse_new_build_warnings_from_directory(build_warnings_direc
 ../../../gcc/gcc/analyzer/access-diagram.cc:1509:33: note: in expansion of macro ‘_’
  1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),
       |                                 ^\n''')
-    new_warnings = parse_new_build_warnings_from_directory(old_build_dir, new_build_dir, PRE_COMMIT)
+    resolved_expected = {a_target: set(), b_target: set()}
+    resolved_expected[b_target].add('''../../../gcc/gcc/analyzer/analyzer.cc:248:25: warning: unknown conversion type character ‘@’ in format [-Wformat=]
+  248 |       pp_printf (&pp, "%@", &event_id);
+      |\n''')
+    new_warnings, resolved_warnings = parse_build_warnings_from_directory(old_build_dir, new_build_dir, PRE_COMMIT)
     print("pre-commit test\n\n\n")
-    for target, warning_set in expected.items():
+    for target, warning_set in new_expected.items():
         print("expected: ", warning_set)
         print("\n\nnew_warnings: ", new_warnings[target])
         assert(new_warnings[target] == warning_set)
+    for target, warning_set in resolved_expected.items():
+        print("expected: ", warning_set)
+        print("\n\resolved_warnings: ", resolved_warnings[target])
+        assert(resolved_warnings[target] == warning_set)
 
-def test_post_commit_parse_new_build_warnings_from_directory(build_warnings_directory_1, build_warnings_directory_2):
+def test_post_commit_parse_build_warnings_from_directory(build_warnings_directory_1, build_warnings_directory_2):
     old_build_dir, old_a, old_b = build_warnings_directory_1
     new_build_dir, _, _ = build_warnings_directory_2
     a_target = parse_target(old_a.name)
@@ -174,7 +186,7 @@ def test_post_commit_parse_new_build_warnings_from_directory(build_warnings_dire
 ../../../gcc/gcc/analyzer/access-diagram.cc:1509:33: note: in expansion of macro ‘_’
  1509 |      s = fmt_styled_string (sm, _("buffer allocated on heap at %@"),
       |                                 ^\n''')
-    new_warnings = parse_new_build_warnings_from_directory(old_build_dir, new_build_dir, POST_COMMIT)
+    new_warnings, resolved_warnings = parse_build_warnings_from_directory(old_build_dir, new_build_dir, POST_COMMIT)
     print("post-commit test\n\n\n")
     for target, warning_set in expected.items():
         print("expected: ", warning_set)
@@ -183,14 +195,16 @@ def test_post_commit_parse_new_build_warnings_from_directory(build_warnings_dire
 
 def test_export_empty_build_warnings():
     empty_warnings_dict = {"foo": set()}
+    warning_type = "New build warnings"
     with NamedTemporaryFile() as tmp:
-        export_build_warnings(empty_warnings_dict, tmp.name)
+        export_build_warnings(empty_warnings_dict, tmp.name, warning_type)
         with open(tmp.name, 'r') as f:
-            assert(f.read() == "New build warnings doesn't exist")
+            assert(f.read() == f"{warning_type} doesn't exist")
 
 def test_export_build_warnings():
     warnings_dict = {"foo": set("bar\n")}
+    warning_type = "New build warnings"
     with NamedTemporaryFile() as tmp:
-        export_build_warnings(warnings_dict, tmp.name)
+        export_build_warnings(warnings_dict, tmp.name, warning_type)
         with open(tmp.name, 'r') as f:
-            assert(f.readline() == "# New build warnings\n")
+            assert(f.readline() == f"# {warning_type}\n")


### PR DESCRIPTION
Parse resolved warnings along with the new warnings.
- Single output option has been splitted into `new_warnings_output` and `resolved_warnings_output`
- warnings are sorted before being exported to a file
- resolved warnings are always parsed between the new build warnings and the old build warnings
- pytest has been accomodated based on these changes