### PR TITLE
update qemu submodule due to missing dependencies

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -55,7 +55,7 @@ def failures_to_summary(failures: Dict[str, List[str]]):
 
     result += build_summary(failures, "New Failures")
     result += build_summary(failures, "Resolved Failures")
-    result += build_summary(failures, "Remaining_Preexisting Failures")
+    result += build_summary(failures, "Remaining Preexisting Failures")
     result += "\n"
 
     print(result)
@@ -218,7 +218,7 @@ def aggregate_summary(failures: Dict[str, List[str]], file_name: str):
         cur_target = None
         while True:
             line = f.readline()
-            if not line or line.startswith("# Remaining_Preexisting Failures"):
+            if not line or line.startswith("# Remaining Preexisting Failures"):
                 break
             temp_comps = line.split(" ")
             if temp_comps[0] == "##":
@@ -228,7 +228,7 @@ def aggregate_summary(failures: Dict[str, List[str]], file_name: str):
                 continue
             if line != "\n":
                 resolved[cur_target].add(line)
-        # begin Remaining_Preexisting Failures
+        # begin Remaining Preexisting Failures
         unresolved: Dict[str, Set[str]] = defaultdict(set)
         cur_target = None
         while True:
@@ -308,7 +308,7 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
-    failures: Dict[str, List[str]] = {"Resolved": [], "Remaining_Preexisting": [], "New": []}
+    failures: Dict[str, List[str]] = {"Resolved": [], "Remaining Preexisting": [], "New": []}
     all_resolved: Dict[str, Dict[str, Set[str]]] = {}
     all_unresolved: Dict[str, Dict[str, Set[str]]] = {}
     all_new: Dict[str, Dict[str, Set[str]]] = {}
@@ -325,10 +325,10 @@ def main():
         failures, args.current_hash, args.patch_name, args.title_prefix
     )
     resolved_markdown = additional_failures_to_markdown(
-        "Resolved", all_resolved, len(failures["Remaining_Preexisting"])
+        "Resolved", all_resolved, len(failures["Remaining Preexisting"])
     )
     new_markdown = additional_failures_to_markdown(
-        "New", all_new, len(failures["Remaining_Preexisting"])
+        "New", all_new, len(failures["Remaining Preexisting"])
     )
 
     markdown = summary_markdown + new_markdown + resolved_markdown
@@ -337,7 +337,7 @@ def main():
         markdown_file.write(markdown)
 
     unresolved_markdown = additional_failures_to_markdown(
-        "Remaining_Preexisting", all_unresolved, len(failures["Remaining_Preexisting"])
+        "Remaining Preexisting", all_unresolved, len(failures["Remaining Preexisting"])
     )
 
     with open("unresolved_important_failures.md", "w") as markdown_file:

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -55,7 +55,7 @@ def failures_to_summary(failures: Dict[str, List[str]]):
 
     result += build_summary(failures, "New Failures")
     result += build_summary(failures, "Resolved Failures")
-    result += build_summary(failures, "Remaining Preexisting Failures")
+    result += build_summary(failures, "Unresolved Failures")
     result += "\n"
 
     print(result)
@@ -218,7 +218,7 @@ def aggregate_summary(failures: Dict[str, List[str]], file_name: str):
         cur_target = None
         while True:
             line = f.readline()
-            if not line or line.startswith("# Remaining Preexisting Failures"):
+            if not line or line.startswith("# Unresolved Failures"):
                 break
             temp_comps = line.split(" ")
             if temp_comps[0] == "##":
@@ -228,7 +228,7 @@ def aggregate_summary(failures: Dict[str, List[str]], file_name: str):
                 continue
             if line != "\n":
                 resolved[cur_target].add(line)
-        # begin Remaining Preexisting Failures
+        # begin unresolved failures
         unresolved: Dict[str, Set[str]] = defaultdict(set)
         cur_target = None
         while True:

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -308,7 +308,7 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
-    failures: Dict[str, List[str]] = {"Resolved": [], "Remaining Preexisting": [], "New": []}
+    failures: Dict[str, List[str]] = {"Resolved": [], "Unresolved": [], "New": []}
     all_resolved: Dict[str, Dict[str, Set[str]]] = {}
     all_unresolved: Dict[str, Dict[str, Set[str]]] = {}
     all_new: Dict[str, Dict[str, Set[str]]] = {}
@@ -325,10 +325,10 @@ def main():
         failures, args.current_hash, args.patch_name, args.title_prefix
     )
     resolved_markdown = additional_failures_to_markdown(
-        "Resolved", all_resolved, len(failures["Remaining Preexisting"])
+        "Resolved", all_resolved, len(failures["Unresolved"])
     )
     new_markdown = additional_failures_to_markdown(
-        "New", all_new, len(failures["Remaining Preexisting"])
+        "New", all_new, len(failures["Unresolved"])
     )
 
     markdown = summary_markdown + new_markdown + resolved_markdown
@@ -337,7 +337,7 @@ def main():
         markdown_file.write(markdown)
 
     unresolved_markdown = additional_failures_to_markdown(
-        "Remaining Preexisting", all_unresolved, len(failures["Remaining Preexisting"])
+        "Unresolved", all_unresolved, len(failures["Unresolved"])
     )
 
     with open("unresolved_important_failures.md", "w") as markdown_file:

--- a/scripts/compare_glibc_log.py
+++ b/scripts/compare_glibc_log.py
@@ -74,9 +74,7 @@ class ClassifedGlibcFailures:
 
     def __str__(self):
         result = self.failure_dict_to_string(self.resolved, "Resolved Failures")
-        result += self.failure_dict_to_string(
-            self.unresolved, "Remaining Preexisting Failures"
-        )
+        result += self.failure_dict_to_string(self.unresolved, "Unresolved Failures")
         result += self.failure_dict_to_string(self.new, "New Failures")
         return result
 
@@ -285,7 +283,7 @@ def failures_to_summary(
     )
     result += glibcfailure_to_summary(
         failures.unresolved,
-        "Remaining Preexisting Failures",
+        "Unresolved Failures",
         previous_hash,
         current_hash,
         current_hash_committed,

--- a/scripts/compare_glibc_log.py
+++ b/scripts/compare_glibc_log.py
@@ -75,7 +75,7 @@ class ClassifedGlibcFailures:
     def __str__(self):
         result = self.failure_dict_to_string(self.resolved, "Resolved Failures")
         result += self.failure_dict_to_string(
-            self.unresolved, "Remaining_Preexisting Failures"
+            self.unresolved, "Remaining Preexisting Failures"
         )
         result += self.failure_dict_to_string(self.new, "New Failures")
         return result
@@ -285,7 +285,7 @@ def failures_to_summary(
     )
     result += glibcfailure_to_summary(
         failures.unresolved,
-        "Remaining_Preexisting Failures",
+        "Remaining Preexisting Failures",
         previous_hash,
         current_hash,
         current_hash_committed,

--- a/scripts/compare_testsuite_log.py
+++ b/scripts/compare_testsuite_log.py
@@ -141,7 +141,7 @@ class ClassifedGccFailures:
     def __str__(self):
         result = self.failure_dict_to_string(self.resolved, "Resolved Failures")
         result += self.failure_dict_to_string(
-            self.unresolved, "Remaining_Preexisting Failures"
+            self.unresolved, "Remaining Preexisting Failures"
         )
         result += self.failure_dict_to_string(self.new, "New Failures")
         return result
@@ -405,7 +405,7 @@ def failures_to_summary(
     )
     result += gccfailure_to_summary(
         failures.unresolved,
-        "Remaining_Preexisting Failures",
+        "Remaining Preexisting Failures",
         previous_hash,
         current_hash,
         current_hash_committed,

--- a/scripts/compare_testsuite_log.py
+++ b/scripts/compare_testsuite_log.py
@@ -140,9 +140,7 @@ class ClassifedGccFailures:
 
     def __str__(self):
         result = self.failure_dict_to_string(self.resolved, "Resolved Failures")
-        result += self.failure_dict_to_string(
-            self.unresolved, "Remaining Preexisting Failures"
-        )
+        result += self.failure_dict_to_string(self.unresolved, "Unresolved Failures")
         result += self.failure_dict_to_string(self.new, "New Failures")
         return result
 
@@ -405,7 +403,7 @@ def failures_to_summary(
     )
     result += gccfailure_to_summary(
         failures.unresolved,
-        "Remaining Preexisting Failures",
+        "Unresolved Failures",
         previous_hash,
         current_hash,
         current_hash_committed,


### PR DESCRIPTION
Revert the verbage update patches for now since those are breaking changes.

One of qemu's submodules lost a dependency which breaks initializing submodules. This affects postcommit weekly runners and prevents them from running