### PR TITLE
add a few missed vector extensions

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -22,6 +22,12 @@ QEMU_EXT_OPTS = {
     "zdinx": "zdinx=true",
     "zicond": "zicond=true",
     "zvbb": "zvbb=true",
+    "zvfh": "zvfh=true",
+    "zvfhmin": "zvfhmin=true",
+    "zvkb": "zvkb=true",
+    "zvkg": "zvkg=true",
+    "zvkn": "zvkn=true",
+    "zvkned": "zvkned=true",
 }
 
 SPIKE_EXT_NOT_ALLOWED = [


### PR DESCRIPTION
precommit was failing one of the tests because it required the zvfh extension (but the dejagnu selector was also off)